### PR TITLE
Strut partial

### DIFF
--- a/include/fensterchef.h
+++ b/include/fensterchef.h
@@ -6,6 +6,7 @@
 #include <xcb/xcb.h>
 #include <xcb/xcb_ewmh.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 
 /* flag used to configure window position, size and border width */
@@ -30,7 +31,7 @@ extern xcb_connection_t         *g_dpy;
 extern xcb_ewmh_connection_t    g_ewmh;
 
 /* 1 while the window manager is running */
-extern unsigned                 g_running;
+extern bool                     g_running;
 
 /* general purpose values */
 extern uint32_t                 g_values[7];

--- a/include/fensterchef.h
+++ b/include/fensterchef.h
@@ -2,18 +2,11 @@
 #define FENSTERCHEF_H
 
 #include <fontconfig/fontconfig.h>
-#include <ft2build.h>
-#include FT_FREETYPE_H
 
-#include <xcb/render.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_ewmh.h>
 
 #include <stdio.h>
-
-#include "action.h"
-#include "frame.h"
-#include "window.h"
 
 /* flag used to configure window position, size and border width */
 #define XCB_CONFIG_SIZE (XCB_CONFIG_WINDOW_X | \
@@ -40,7 +33,7 @@ extern xcb_ewmh_connection_t    g_ewmh;
 extern unsigned                 g_running;
 
 /* general purpose values */
-extern uint32_t                 g_values[6];
+extern uint32_t                 g_values[7];
 
 /* Initialize most of fensterchef data and set root window flags. */
 int init_fensterchef(void);

--- a/include/frame.h
+++ b/include/frame.h
@@ -3,9 +3,6 @@
 
 #include <xcb/xcb.h>
 
-/* forward declaration */
-struct window;
-
 /* Frames are used to partition a monitor into multiple rectangular regions.
  *
  * When a frame has one child, it must have a second one, so either BOTH left

--- a/include/keybind.h
+++ b/include/keybind.h
@@ -3,6 +3,8 @@
 
 #include <xcb/xcb.h>
 
+#include "action.h"
+
 /* Grab all keys so we receive the keypress events for them. */
 void init_keybinds(void);
 

--- a/include/render_font.h
+++ b/include/render_font.h
@@ -6,6 +6,7 @@
 #include FT_FREETYPE_H
 
 #include <xcb/xcb.h>
+#include <xcb/render.h>
 
 /* Initializes all parts needed for drawing fonts.
  *

--- a/include/screen.h
+++ b/include/screen.h
@@ -51,9 +51,12 @@ typedef struct monitor {
     /* temporary flag for merging */
     unsigned is_free : 1;
 
+    /* region of the monitor cut off */
+    xcb_ewmh_get_extents_reply_t struts;
+
     /* root frame */
     struct frame *frame;
-    
+
     /* next/prev monitor */
     struct monitor *prev;
     struct monitor *next;
@@ -79,6 +82,9 @@ Monitor *get_monitor_from_rectangle(int32_t x, int32_t y,
  * @return NULL when randr is not supported or when there are no monitors.
  */
 Monitor *query_monitors(void);
+
+/* Updates the struts of all monitors and then correctly sizes the frame. */
+void reconfigure_monitor_frame_sizes(void);
 
 /* Merges given monitor linked list into the screen's monitor list.
  *

--- a/include/screen.h
+++ b/include/screen.h
@@ -3,6 +3,8 @@
 
 #include <xcb/randr.h>
 
+#include "util.h" // Position, Size
+
 /* stock object indexes */
 enum {
     STOCK_WHITE_PEN,
@@ -53,6 +55,10 @@ typedef struct monitor {
 
     /* region of the monitor cut off */
     xcb_ewmh_get_extents_reply_t struts;
+
+    /* the position and size of the monitor */
+    Position position;
+    Size size;
 
     /* root frame */
     struct frame *frame;

--- a/include/util.h
+++ b/include/util.h
@@ -1,6 +1,7 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "xalloc.h"

--- a/include/window.h
+++ b/include/window.h
@@ -3,42 +3,18 @@
 
 #include <stdint.h>
 
-#include <fontconfig/fontconfig.h> // FcChar8
-
 #include <xcb/xcb.h> // xcb_window_t
-#include <xcb/xcb_icccm.h> // xcb_size_hints_t, xcb_icccm_wm_hints_t
 
 #include "util.h"
+
+#include "window_properties.h"
+#include "window_state.h"
 
 /* the number the first window gets assigned */
 #define FIRST_WINDOW_NUMBER 1
 
-/* all possible window states */
-#define WINDOW_STATE_HIDDEN 0
-#define WINDOW_STATE_SHOWN 1
-#define WINDOW_STATE_POPUP 2
-#define WINDOW_STATE_IGNORE 3
-#define WINDOW_STATE_FULLSCREEN 4
-
-typedef struct window_state {
-    /* the current window state */
-    unsigned current : 3;
-    /* the previous window state */
-    unsigned previous : 3;
-    /* if the window was forced to be a certain state */
-    unsigned is_forced : 1;
-} WindowState;
-
 /* A window is a wrapper around an xcb window, it is always part of a global
  * linked list and has a unique id.
- *
- * A window may be in different states:
- * HIDDEN: The window is not shown but would usually go in the tiling layout.
- * SHOWN: The window is part of the current tiling layout.
- * POPUP: The window is a popup window, it may or may not be visible.
- * IGNORE: The window was once registered by the WM but the user decided to
- *      ignore it. It does not appear when cycling through windows.
- * FULLSCREEN: The window covers an entire monitor.
  */
 typedef struct window {
     /* the actual X window */
@@ -47,12 +23,8 @@ typedef struct window {
     /* frame this window is contained in */
     struct frame *frame;
 
-    /* xcb size hints of the window */
-    xcb_size_hints_t size_hints;
-    /* special window manager hints */
-    xcb_icccm_wm_hints_t wm_hints;
-    /* short window title */
-    FcChar8 short_title[256];
+    /* the window properties */
+    WindowProperties properties;
 
     /* current window position and size */
     Position position;
@@ -88,15 +60,6 @@ Window *create_window(xcb_window_t xcb_window);
  * This does NOT destroy the underlying xcb window.
  */
 void destroy_window(Window *window);
-
-/* Update the short_title of the window. */
-void update_window_name(Window *window);
-
-/* Update the size_hints of the window. */
-void update_window_size_hints(Window *window);
-
-/* Update the wm_hints of the window. */
-void update_window_wm_hints(Window *window);
 
 /* Set the position and size of a window. */
 void set_window_size(Window *window, int32_t x, int32_t y, uint32_t width,
@@ -162,18 +125,5 @@ Window *get_previous_hidden_window(Window *window);
  * from their respective frame and window which makes this a very safe function.
  */
 void link_window_and_frame(Window *window, Frame *frame);
-
-/* -- Implemented in window_state.c -- */
-
-/* Predict what state the window is expected to be in based on the X11
- * properties.
- */
-unsigned predict_window_state(Window *window);
-
-/* Change the state to given value and reconfigures the window.
- *
- * @force is used to force the change of the window state.
- */
-void set_window_state(Window *window, unsigned state, unsigned force);
 
 #endif

--- a/include/window.h
+++ b/include/window.h
@@ -13,6 +13,10 @@
 /* the number the first window gets assigned */
 #define FIRST_WINDOW_NUMBER 1
 
+/* forward declaration */
+struct frame;
+typedef struct frame Frame;
+
 /* A window is a wrapper around an xcb window, it is always part of a global
  * linked list and has a unique id.
  */
@@ -21,10 +25,13 @@ typedef struct window {
     xcb_window_t xcb_window;
 
     /* frame this window is contained in */
-    struct frame *frame;
+    Frame *frame;
 
     /* the window properties */
     WindowProperties properties;
+
+    /* the window state */
+    WindowState state;
 
     /* current window position and size */
     Position position;
@@ -33,12 +40,6 @@ typedef struct window {
     /* position and size when the window was in popup state */
     Position popup_position;
     Size popup_size;
-
-    /* the window state */
-    WindowState state;
-
-    /* if the window has focus */
-    unsigned focused : 1;
 
     /* the id of this window */
     uint32_t number;

--- a/include/window_properties.h
+++ b/include/window_properties.h
@@ -6,14 +6,22 @@
 #include <xcb/xcb_icccm.h> // xcb_size_hints_t, xcb_icccm_wm_hints_t,
                            // xcb_ewmh_wm_struct_partial_t
 
+/* these correspond to X atoms */
 typedef enum window_property {
+    /* WM_NAME */
     WINDOW_PROPERTY_NAME,
+    /* WM_NORMAL_HINTS */
     WINDOW_PROPERTY_SIZE_HINTS,
+    /* WM_HINTS */
     WINDOW_PROPERTY_HINTS,
+    /* WM_STRUT / WM_STRUT_PARTIAL */
     WINDOW_PROPERTY_STRUT,
+    /* WM_STATE -> list of atoms that may contain WM_STATE_FULLSCREEN */
     WINDOW_PROPERTY_FULLSCREEN,
-    WINDOW_PROPERTY_TRANSIENT,
+    /* WM_TRANSIENT_FOR */
+    WINDOW_PROPERTY_TRANSIENT_FOR,
 
+    /* maximum possible value for a window property */
     WINDOW_PROPERTY_MAX,
 } window_property_t;
 
@@ -33,15 +41,18 @@ typedef struct window_properties {
     xcb_icccm_wm_hints_t hints;
     /* window struts (extents) */
     xcb_ewmh_wm_strut_partial_t struts;
-    /* if the window has the strut partial property */
-    unsigned has_strut : 1;
-    /* if the window has the strut partial property */
-    unsigned has_strut_partial : 1;
+    /* the window this window is transient for */
+    xcb_window_t transient_for;
     /* if the window is a fullscreen window */
     unsigned is_fullscreen : 1;
-    /* if the window is a transient window */
-    unsigned is_transient : 1;
 } WindowProperties;
+
+/* Checks if given window has any struts set. */
+static inline unsigned is_strut_empty(xcb_ewmh_wm_strut_partial_t *struts)
+{
+    return struts->left == 0 && struts->top == 0 &&
+        struts->right == 0 && struts->bottom == 0;
+}
 
 /* Update the given property of given window. */
 void update_window_property(Window *window, window_property_t property);

--- a/include/window_properties.h
+++ b/include/window_properties.h
@@ -1,0 +1,52 @@
+#ifndef WINDOW_PROPERTIES_H
+#define WINDOW_PROPERTIES_H
+
+#include <fontconfig/fontconfig.h> // FcChar8
+
+#include <xcb/xcb_icccm.h> // xcb_size_hints_t, xcb_icccm_wm_hints_t,
+                           // xcb_ewmh_wm_struct_partial_t
+
+typedef enum window_property {
+    WINDOW_PROPERTY_NAME,
+    WINDOW_PROPERTY_SIZE_HINTS,
+    WINDOW_PROPERTY_HINTS,
+    WINDOW_PROPERTY_STRUT,
+    WINDOW_PROPERTY_FULLSCREEN,
+    WINDOW_PROPERTY_TRANSIENT,
+
+    WINDOW_PROPERTY_MAX,
+} window_property_t;
+
+/* forward declaration */
+struct window;
+typedef struct window Window;
+
+/* Properties are additional fields that applications set to describe a window.
+ * These properties are set up to date using the xcb atom properties.
+ */
+typedef struct window_properties {
+    /* short window name */
+    FcChar8 short_name[256];
+    /* xcb size hints of the window */
+    xcb_size_hints_t size_hints;
+    /* special window manager hints */
+    xcb_icccm_wm_hints_t hints;
+    /* window struts (extents) */
+    xcb_ewmh_wm_strut_partial_t struts;
+    /* if the window has the strut partial property */
+    unsigned has_strut : 1;
+    /* if the window has the strut partial property */
+    unsigned has_strut_partial : 1;
+    /* if the window is a fullscreen window */
+    unsigned is_fullscreen : 1;
+    /* if the window is a transient window */
+    unsigned is_transient : 1;
+} WindowProperties;
+
+/* Update the given property of given window. */
+void update_window_property(Window *window, window_property_t property);
+
+/* Update all properties of given window. */
+void update_all_window_properties(Window *window);
+
+#endif

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -20,11 +20,11 @@ typedef struct window Window;
  */
 typedef struct window_state {
     /* if the window was ever mapped */
-    unsigned is_mappable : 1;
+    bool is_mappable;
     /* if the window is visible (mapped) */
-    unsigned is_visible : 1;
+    bool is_visible;
     /* if the window was forced to be a certain mode */
-    unsigned is_mode_forced : 1;
+    bool is_mode_forced;
     /* the current window state */
     window_mode_t current_mode;
     /* the previous window state */

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -1,0 +1,46 @@
+#ifndef WINDOW_STATE_H
+#define WINDOW_STATE_H
+
+/* all possible window states */
+#define WINDOW_STATE_HIDDEN 0
+#define WINDOW_STATE_SHOWN 1
+#define WINDOW_STATE_POPUP 2
+#define WINDOW_STATE_IGNORE 3
+#define WINDOW_STATE_FULLSCREEN 4
+
+/* HIDDEN: The window is not shown but would usually go in the tiling layout.
+ * SHOWN: The window is part of the current tiling layout.
+ * POPUP: The window is a popup window, it may or may not be visible.
+ * IGNORE: The window was once registered by the WM but the user decided to
+ *      ignore it. It does not appear when cycling through windows.
+ * FULLSCREEN: The window covers an entire monitor.
+ */
+
+/* forward declaration */
+struct window;
+typedef struct window Window;
+
+/* The state of the window signals our window manager what kind of window it is
+ * and how the window should behave.
+ */
+typedef struct window_state {
+    /* the current window state */
+    unsigned current : 3;
+    /* the previous window state */
+    unsigned previous : 3;
+    /* if the window was forced to be a certain state */
+    unsigned is_forced : 1;
+} WindowState;
+
+/* Predict what state the window is expected to be in based on the X11
+ * properties.
+ */
+unsigned predict_window_state(Window *window);
+
+/* Change the state to given value and reconfigures the window.
+ *
+ * @force is used to force the change of the window state.
+ */
+void set_window_state(Window *window, unsigned state, unsigned force);
+
+#endif

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -1,20 +1,15 @@
 #ifndef WINDOW_STATE_H
 #define WINDOW_STATE_H
 
-/* all possible window states */
-#define WINDOW_STATE_HIDDEN 0
-#define WINDOW_STATE_SHOWN 1
-#define WINDOW_STATE_POPUP 2
-#define WINDOW_STATE_IGNORE 3
-#define WINDOW_STATE_FULLSCREEN 4
-
-/* HIDDEN: The window is not shown but would usually go in the tiling layout.
- * SHOWN: The window is part of the current tiling layout.
- * POPUP: The window is a popup window, it may or may not be visible.
- * IGNORE: The window was once registered by the WM but the user decided to
- *      ignore it. It does not appear when cycling through windows.
- * FULLSCREEN: The window covers an entire monitor.
- */
+/* the mode of the window */
+typedef enum window_mode {
+    /* the window is part of the tiling layout (if visible) */
+    WINDOW_MODE_TILING,
+    /* the window is a popup window */
+    WINDOW_MODE_POPUP,
+    /* the window is a fullscreen window */
+    WINDOW_MODE_FULLSCREEN,
+} window_mode_t;
 
 /* forward declaration */
 struct window;
@@ -24,23 +19,33 @@ typedef struct window Window;
  * and how the window should behave.
  */
 typedef struct window_state {
+    /* if the window was ever mapped */
+    unsigned is_mappable : 1;
+    /* if the window is visible (mapped) */
+    unsigned is_visible : 1;
+    /* if the window was forced to be a certain mode */
+    unsigned is_mode_forced : 1;
     /* the current window state */
-    unsigned current : 3;
+    window_mode_t current_mode;
     /* the previous window state */
-    unsigned previous : 3;
-    /* if the window was forced to be a certain state */
-    unsigned is_forced : 1;
+    window_mode_t previous_mode;
 } WindowState;
 
-/* Predict what state the window is expected to be in based on the X11
+/* Predict what mode the window is expected to be in based on the X
  * properties.
  */
-unsigned predict_window_state(Window *window);
+window_mode_t predict_window_mode(Window *window);
 
-/* Change the state to given value and reconfigures the window.
+/* Change the mode to given value and reconfigures the window if it is visible.
  *
- * @force is used to force the change of the window state.
+ * @force_mode is used to force the change of the window mode.
  */
-void set_window_state(Window *window, unsigned state, unsigned force);
+void set_window_mode(Window *window, window_mode_t mode, bool force_mode);
+
+/* Show the window by positioning it and mapping it to the X server. */
+void show_window(Window *window);
+
+/* Hide the window by unmapping it to the X server. */
+void hide_window(Window *window);
 
 #endif

--- a/src/event.c
+++ b/src/event.c
@@ -112,9 +112,6 @@ static void handle_button_release(xcb_button_release_event_t *event)
 /* Property notifications are sent when a window atom changes, this can
  * be many atoms, but the main ones handled are WM_NAME, WM_SIZE_HINTS,
  * WM_HINTS.
- *
- * TODO: make special handling for WM_NORMAL_HINTS just like with WM_NAME
- * for fullscreen.
  */
 static void handle_property_notify(xcb_property_notify_event_t *event)
 {
@@ -128,12 +125,20 @@ static void handle_property_notify(xcb_property_notify_event_t *event)
     }
 
     if (event->atom == XCB_ATOM_WM_NAME) {
-        update_window_name(window);
+        update_window_property(window, WINDOW_PROPERTY_NAME);
     } else if (event->atom == XCB_ATOM_WM_SIZE_HINTS) {
-        update_window_size_hints(window);
+        update_window_property(window, WINDOW_PROPERTY_SIZE_HINTS);
     } else if (event->atom == XCB_ATOM_WM_HINTS) {
-        update_window_wm_hints(window);
+        update_window_property(window, WINDOW_PROPERTY_HINTS);
+    } else if (event->atom == g_ewmh._NET_WM_STRUT ||
+            event->atom == g_ewmh._NET_WM_STRUT_PARTIAL) {
+        update_window_property(window, WINDOW_PROPERTY_STRUT);
+    } else if (event->atom == g_ewmh._NET_WM_STATE) {
+        update_window_property(window, WINDOW_PROPERTY_FULLSCREEN);
+    } else if (event->atom == XCB_ATOM_WM_TRANSIENT_FOR) {
+        update_window_property(window, WINDOW_PROPERTY_TRANSIENT);
     }
+
     set_window_state(window, predict_window_state(window), 0);
 }
 

--- a/src/event.c
+++ b/src/event.c
@@ -45,6 +45,10 @@ static void handle_map_request(xcb_map_request_event_t *event)
     }
     window = create_window(event->window);
     set_focus_window(window);
+    if (window->properties.has_strut ||
+            window->properties.has_strut_partial) {
+        reconfigure_monitor_frame_sizes();
+    }
 }
 
 /* Button press events are sent when the mouse is pressed together with
@@ -140,6 +144,11 @@ static void handle_property_notify(xcb_property_notify_event_t *event)
     }
 
     set_window_state(window, predict_window_state(window), 0);
+
+    if (window->properties.has_strut ||
+            window->properties.has_strut_partial) {
+        reconfigure_monitor_frame_sizes();
+    }
 }
 
 /* Unmap notifications are sent after a window decided it wanted to not be seen
@@ -152,6 +161,10 @@ void handle_unmap_notify(xcb_unmap_notify_event_t *event)
     window = get_window_of_xcb_window(event->window);
     if (window != NULL) {
         set_window_state(window, WINDOW_STATE_HIDDEN, 1);
+        if (window->properties.has_strut ||
+                window->properties.has_strut_partial) {
+            reconfigure_monitor_frame_sizes();
+        }
     }
 }
 

--- a/src/fensterchef.c
+++ b/src/fensterchef.c
@@ -27,7 +27,7 @@ xcb_ewmh_connection_t   g_ewmh;
 unsigned                g_running;
 
 /* general purpose values */
-uint32_t                g_values[6];
+uint32_t                g_values[7];
 
 /* Handle an incoming alarm. */
 static void alarm_handler(int sig)

--- a/src/fensterchef.c
+++ b/src/fensterchef.c
@@ -24,7 +24,7 @@ xcb_connection_t        *g_dpy;
 xcb_ewmh_connection_t   g_ewmh;
 
 /* 1 while the window manager is running */
-unsigned                g_running;
+bool                    g_running;
 
 /* general purpose values */
 uint32_t                g_values[7];

--- a/src/frame.c
+++ b/src/frame.c
@@ -5,6 +5,7 @@
 #include "log.h"
 #include "screen.h"
 #include "util.h"
+#include "window.h"
 #include "xalloc.h"
 
 /* the currently selected/focused frame */
@@ -86,8 +87,7 @@ void resize_frame(Frame *frame, int32_t x, int32_t y,
 /* Set the frame in focus, this also focuses the inner window if it exists. */
 void set_focus_frame(Frame *frame)
 {
-    if (frame->window == NULL ||
-            set_focus_window(frame->window) != 0) {
+    if (set_focus_window(frame->window) != 0) {
         /* setting focus to the root essentially removes focus from all other
          * windows
          */

--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@ int main(void)
             init_keymap() != 0 ||
             /* TODO: take user chosen screen. */
             init_screen(g_ewmh.screens[0]) != 0) {
-        quit_fensterchef(1);
+        quit_fensterchef(EXIT_FAILURE);
     }
 
     init_monitors();
@@ -34,10 +34,10 @@ int main(void)
 
     g_cur_frame = get_primary_monitor()->frame;
 
-    g_running = 1;
+    g_running = true;
     while (g_running) {
         if (xcb_connection_has_error(g_dpy) > 0) {
-            quit_fensterchef(1);
+            quit_fensterchef(EXIT_FAILURE);
         }
         event = xcb_wait_for_event(g_dpy);
         if (event != NULL) {
@@ -47,5 +47,5 @@ int main(void)
         }
     }
 
-    quit_fensterchef(0);
+    quit_fensterchef(EXIT_SUCCESS);
 }

--- a/src/screen.c
+++ b/src/screen.c
@@ -26,7 +26,7 @@
                          XCB_EVENT_MASK_ENTER_WINDOW)
 
 /* if randr is enabled for usage */
-static unsigned randr_enabled = 0;
+static bool randr_enabled = false;
 
 /* the actively used screen */
 Screen *g_screen;
@@ -225,7 +225,7 @@ void init_monitors(void)
     } else {
         free(version);
 
-        randr_enabled = 1;
+        randr_enabled = true;
         randr_event_base = extension->first_event;
     }
 

--- a/src/tiling.c
+++ b/src/tiling.c
@@ -1,9 +1,11 @@
 #include <inttypes.h>
 
 #include "fensterchef.h"
+#include "frame.h"
 #include "log.h"
 #include "tiling.h"
 #include "util.h"
+#include "window.h"
 
 /* Split a frame horizontally or vertically.
  *
@@ -63,8 +65,10 @@ void split_frame(Frame *split_from, int is_split_vert)
 
     window = get_next_hidden_window(left->window);
     if (window != NULL) {
+        /* show window in the right frame */
+        set_window_mode(window, WINDOW_MODE_TILING, 1);
         g_cur_frame = right;
-        set_window_state(window, WINDOW_STATE_SHOWN, 1);
+        show_window(window);
     }
 
     if (left->window != NULL) {
@@ -86,10 +90,8 @@ static void unmap_and_destroy_recursively(Frame *frame)
         unmap_and_destroy_recursively(frame->left);
         unmap_and_destroy_recursively(frame->right);
     } else if (frame->window != NULL) {
-        frame->window->state.previous = frame->window->state.current;
-        frame->window->state.current = WINDOW_STATE_HIDDEN;
-        frame->window->focused = 0;
         frame->window->frame = NULL;
+        frame->window->state.is_visible = false;
         xcb_unmap_window(g_dpy, frame->window->xcb_window);
     }
     free(frame);

--- a/src/window_list.c
+++ b/src/window_list.c
@@ -36,7 +36,8 @@ static int render_window_list(Window *selected)
     max_width = 0;
     for (Window *w = g_first_window; w != NULL; w = w->next) {
         window_count++;
-        measure_text(w->short_title, strlen((char*) w->short_title), &tm);
+        measure_text(w->properties.short_name,
+                strlen((char*) w->properties.short_name), &tm);
         max_width = MAX(max_width, tm.total_width);
     }
 
@@ -77,7 +78,7 @@ static int render_window_list(Window *selected)
             bg_color.blue = 0xff00;
         }
 
-        marker_char = w->short_title;
+        marker_char = w->properties.short_name;
         while (isdigit(marker_char[0])) {
             marker_char++;
         }
@@ -88,8 +89,8 @@ static int render_window_list(Window *selected)
                 w->focused ? '*' :
                 w->state.current == WINDOW_STATE_SHOWN ? '+' : '-',
 
-        draw_text(g_screen->window_list_window, w->short_title,
-                strlen((char*) w->short_title), bg_color, &rect,
+        draw_text(g_screen->window_list_window, w->properties.short_name,
+                strlen((char*) w->properties.short_name), bg_color, &rect,
                 pen, WINDOW_PADDING / 2,
                 rect.y + tm.ascent + WINDOW_PADDING / 2);
         rect.y += rect.height;

--- a/src/window_properties.c
+++ b/src/window_properties.c
@@ -106,7 +106,7 @@ static void update_window_fullscreen(Window *window)
             g_ewmh._NET_WM_STATE, XCB_GET_PROPERTY_TYPE_ANY, 0, UINT32_MAX);
     state_reply = xcb_get_property_reply(g_dpy, state_cookie, NULL);
     if (state_reply == NULL) {
-        window->properties.is_fullscreen = 0;
+        window->properties.is_fullscreen = false;
         return;
     }
 
@@ -116,7 +116,7 @@ static void update_window_fullscreen(Window *window)
         num_atoms /= state_reply->format / 8;
         for (int i = 0; i < num_atoms; i++) {
             if (atoms[i] == g_ewmh._NET_WM_STATE_FULLSCREEN) {
-                window->properties.is_fullscreen = 1;
+                window->properties.is_fullscreen = true;
                 break;
             }
         }

--- a/src/window_properties.c
+++ b/src/window_properties.c
@@ -1,0 +1,154 @@
+#include <inttypes.h>
+
+#include "fensterchef.h"
+#include "window.h"
+
+/* Update the short_name of the window. */
+static void update_window_name(Window *window)
+{
+    xcb_get_property_cookie_t name_cookie;
+    xcb_ewmh_get_utf8_strings_reply_t data;
+
+    name_cookie = xcb_ewmh_get_wm_name(&g_ewmh, window->xcb_window);
+
+    if (!xcb_ewmh_get_wm_name_reply(&g_ewmh, name_cookie, &data, NULL)) {
+        snprintf((char*) window->properties.short_name,
+                sizeof(window->properties.short_name),
+                "%" PRId32 "_", window->number);
+        return;
+    }
+
+    snprintf((char*) window->properties.short_name,
+            sizeof(window->properties.short_name),
+        "%" PRId32 "_%.*s",
+            window->number,
+            (int) MIN(data.strings_len, (uint32_t) INT_MAX), data.strings);
+
+    xcb_ewmh_get_utf8_strings_reply_wipe(&data);
+}
+
+/* Update the size_hints of the window. */
+static void update_window_size_hints(Window *window)
+{
+    xcb_get_property_cookie_t size_hints_cookie;
+
+    size_hints_cookie = xcb_icccm_get_wm_size_hints(g_dpy, window->xcb_window,
+            XCB_ATOM_WM_NORMAL_HINTS);
+    if (!xcb_icccm_get_wm_size_hints_reply(g_dpy, size_hints_cookie,
+                &window->properties.size_hints, NULL)) {
+        window->properties.size_hints.flags = 0;
+    }
+}
+
+/* Update the hints of the window. */
+static void update_window_hints(Window *window)
+{
+    xcb_get_property_cookie_t hints_cookie;
+
+    hints_cookie = xcb_icccm_get_wm_hints(g_dpy, window->xcb_window);
+    if (!xcb_icccm_get_wm_hints_reply(g_dpy, hints_cookie,
+                &window->properties.hints, NULL)) {
+        window->properties.hints.flags = 0;
+    }
+}
+
+/* Update the strut partial property of the window. */
+static void update_window_strut(Window *window)
+{
+    xcb_get_property_cookie_t strut_partial_cookie;
+    xcb_get_property_cookie_t strut_cookie;
+    xcb_ewmh_get_extents_reply_t struts;
+
+    strut_partial_cookie = xcb_ewmh_get_wm_strut_partial(&g_ewmh,
+            window->xcb_window);
+    if (xcb_ewmh_get_wm_strut_partial_reply(&g_ewmh, strut_partial_cookie,
+                &window->properties.struts, NULL)) {
+        window->properties.has_strut_partial = 1;
+        return;
+    }
+
+    window->properties.has_strut_partial = 0;
+
+    /* _NET_WM_STRUT is older than _NET_WM_STRUT_PARTIAL, fall back to it when
+     * there is so strut partial
+     */
+    strut_cookie = xcb_ewmh_get_strut(&g_ewmh, window->xcb_window);
+    if (xcb_ewmh_get_wm_strut(&g_ewmh, strut_cookie, &struts, NULL)) {
+        window->properties.has_strut = 1;
+        window->properties.struts.left = struts.left;
+        window->properties.struts.top = struts.top;
+        window->properties.struts.right = struts.right;
+        window->properties.struts.bottom = struts.bottom;
+    } else {
+        window->properties.has_strut = 0;
+    }
+}
+
+/* Update the transient property of the window. */
+static void update_window_transient(Window *window)
+{
+    xcb_window_t transient;
+    xcb_get_property_cookie_t transient_cookie;
+
+    transient_cookie = xcb_icccm_get_wm_transient_for(g_dpy,
+            window->xcb_window);
+    if (xcb_icccm_get_wm_transient_for_reply(g_dpy, transient_cookie,
+                &transient, NULL) && transient != 0) {
+        window->properties.is_transient = 1;
+    } else {
+        window->properties.is_transient = 0;
+    }
+}
+
+/* Update the fullscreen property of the window. */
+static void update_window_fullscreen(Window *window)
+{
+    xcb_get_property_reply_t *state_reply;
+    xcb_get_property_cookie_t state_cookie;
+    xcb_atom_t *atoms;
+    int num_atoms;
+
+    state_cookie = xcb_get_property(g_dpy, 0, window->xcb_window,
+            g_ewmh._NET_WM_STATE, XCB_GET_PROPERTY_TYPE_ANY, 0, UINT32_MAX);
+    state_reply = xcb_get_property_reply(g_dpy, state_cookie, NULL);
+    if (state_reply == NULL) {
+        window->properties.is_fullscreen = 0;
+        return;
+    }
+
+    if (state_reply->format != 0) {
+        atoms = xcb_get_property_value(state_reply);
+        num_atoms = xcb_get_property_value_length(state_reply);
+        num_atoms /= state_reply->format / 8;
+        for (int i = 0; i < num_atoms; i++) {
+            if (atoms[i] == g_ewmh._NET_WM_STATE_FULLSCREEN) {
+                window->properties.is_fullscreen = 1;
+                break;
+            }
+        }
+    }
+    free(state_reply);
+}
+
+/* Update the given property of given window. */
+void update_window_property(Window *window, window_property_t property)
+{
+    static void (*const updaters[])(Window *window) = {
+        [WINDOW_PROPERTY_NAME] = update_window_name,
+        [WINDOW_PROPERTY_SIZE_HINTS] = update_window_size_hints,
+        [WINDOW_PROPERTY_HINTS] = update_window_hints,
+        [WINDOW_PROPERTY_STRUT] = update_window_strut,
+        [WINDOW_PROPERTY_FULLSCREEN] = update_window_fullscreen,
+        [WINDOW_PROPERTY_TRANSIENT] = update_window_transient,
+    };
+
+    updaters[property](window);
+}
+
+/* Update all properties of given window. */
+void update_all_window_properties(Window *window)
+{
+    for (window_property_t i = 0; i < WINDOW_PROPERTY_MAX; i++) {
+        update_window_property(window, i);
+    }
+}

--- a/src/window_properties.c
+++ b/src/window_properties.c
@@ -72,8 +72,8 @@ static void update_window_strut(Window *window)
     /* _NET_WM_STRUT is older than _NET_WM_STRUT_PARTIAL, fall back to it when
      * there is so strut partial
      */
-    strut_cookie = xcb_ewmh_get_strut(&g_ewmh, window->xcb_window);
-    if (xcb_ewmh_get_wm_strut(&g_ewmh, strut_cookie, &struts, NULL)) {
+    strut_cookie = xcb_ewmh_get_wm_strut(&g_ewmh, window->xcb_window);
+    if (xcb_ewmh_get_wm_strut_reply(&g_ewmh, strut_cookie, &struts, NULL)) {
         window->properties.has_strut = 1;
         window->properties.struts.left = struts.left;
         window->properties.struts.top = struts.top;

--- a/src/window_state.c
+++ b/src/window_state.c
@@ -100,7 +100,7 @@ static void configure_popup_size(Window *window)
             window->size.width, window->size.height);
 
     if (window->popup_size.width == 0) {
-        if ((window->properties.size_hints.flags & XCB_ICCCM_SIZE_HINT_US_SIZE)) {
+        if ((window->properties.size_hints.flags & XCB_ICCCM_SIZE_HINT_P_SIZE)) {
             width = window->properties.size_hints.width;
             height = window->properties.size_hints.height;
         } else {
@@ -118,7 +118,7 @@ static void configure_popup_size(Window *window)
             height = MIN(height, (uint32_t) window->properties.size_hints.max_height);
         }
 
-        if ((window->properties.size_hints.flags & XCB_ICCCM_SIZE_HINT_US_POSITION)) {
+        if ((window->properties.size_hints.flags & XCB_ICCCM_SIZE_HINT_P_POSITION)) {
             x = window->properties.size_hints.x;
             y = window->properties.size_hints.y;
         } else {


### PR DESCRIPTION
Nun gibt es window mode und die flags wie is_visible in der window state. Das System ist nun viel erweiterbarer und sinnvoller gestaltet.

Struts werden nun voll unterstützt. Das heißt, wenn ein Fenster, einen Ort auf dem Screen zugesprochen haben möchte, werden die Frames in den Monitoren richtig konfiguriert (die Größe angepasst).

Ich weiß nicht wofür das Wort "strut" steht, vielleicht kann man das recherchieren. Echt ein seltsames Wort.