### PR TITLE
behebe keymap Probleme

### DIFF
--- a/include/keymap.h
+++ b/include/keymap.h
@@ -7,6 +7,9 @@
 /* Initializes the keymap so the below functions can be used. */
 int init_keymap(void);
 
+/* Refresh the keymap if a mapping notify event arrives. */
+void refresh_keymap(xcb_mapping_notify_event_t *event);
+
 /* Get a keysym from a keycode. */
 xcb_keysym_t get_keysym(xcb_keycode_t keycode);
 

--- a/src/action.c
+++ b/src/action.c
@@ -65,7 +65,11 @@ static void show_window_list(void)
         return;
     }
 
-    set_focus_window(window);
+    if (window->frame != NULL) {
+        set_focus_frame(window->frame);
+    } else {
+        set_focus_window(window);
+    }
 
     if (window->state.is_visible) {
         set_window_above(window);

--- a/src/event.c
+++ b/src/event.c
@@ -5,6 +5,7 @@
 #include "action.h"
 #include "fensterchef.h"
 #include "keybind.h"
+#include "keymap.h"
 #include "log.h"
 #include "screen.h"
 #include "util.h"
@@ -284,6 +285,14 @@ void handle_screen_change(xcb_randr_screen_change_notify_event_t *event)
     merge_monitors(query_monitors());
 }
 
+/* Mapping notifications are sent when the modifier keys or keyboard mapping
+ * changes.
+ */
+void handle_mapping_notify(xcb_mapping_notify_event_t *event)
+{
+    refresh_keymap(event);
+}
+
 /* Handle the given xcb event.
  *
  * Descriptions for each event are above each handler.
@@ -358,6 +367,11 @@ void handle_event(xcb_generic_event_t *event)
     /* a key was pressed */
     case XCB_KEY_PRESS:
         handle_key_press((xcb_key_press_event_t*) event);
+        break;
+
+    /* keyboard mapping changed */
+    case XCB_MAPPING_NOTIFY:
+        handle_mapping_notify((xcb_mapping_notify_event_t*) event);
         break;
     }
 }

--- a/src/keybind.c
+++ b/src/keybind.c
@@ -1,9 +1,7 @@
-/* This file handles translation of keysyms to keycodes and vise versa.
- *
- * It also handles keybinds.
+/* This file's purpose is to grab all keybinds to handle associations between
+ * actions and key presses.
  */
 
-#include <xcb/xcb_keysyms.h>
 #include <X11/keysym.h>
 
 #include "action.h"

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -1,9 +1,11 @@
 #include "fensterchef.h"
+#include "keybind.h"
 #include "keymap.h"
 
 /* symbol translation table */
 static xcb_key_symbols_t *keysyms;
 
+/* Initializes the keymap so the below functions can be used. */
 int init_keymap(void)
 {
     keysyms = xcb_key_symbols_alloc(g_dpy);
@@ -11,6 +13,14 @@ int init_keymap(void)
         return 1;
     }
     return 0;
+}
+
+/* Refresh the keymap if a mapping notify event arrives. */
+void refresh_keymap(xcb_mapping_notify_event_t *event)
+{
+    (void) xcb_refresh_keyboard_mapping(keysyms, event);
+    /* regrab all keys */
+    init_keybinds();
 }
 
 /* Get a keysym from a keycode. */


### PR DESCRIPTION
Nun wird die Keysymbol translation table refreshed und alle keybinds neu gegrabbed, wenn das Keyboard Mapping sich ändert.