### PR TITLE
Focus handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ OBJECTS := $(patsubst $(SRC)/%.c,$(BUILD)/%.o,$(SOURCES))
 # Get dependencies
 DEPENDENCIES := $(patsubst %.o,%.d,$(OBJECTS))
 
+# Sandbox parameters
+SANDBOX_DISPLAY := 8
+SANDBOX := Xephyr :$(SANDBOX_DISPLAY) +extension RANDR -br -ac -noreset -screen 800x600
+
 .PHONY: default
 default: build
 
@@ -38,24 +42,15 @@ $(BUILD)/$(RUN): $(OBJECTS)
 	gcc $(DEBUG_FLAGS) $(C_FLAGS) $(OBJECTS) -o $@ $(C_LIBS)
 
 # Functions
-.PHONY: build test test-multi stop release clean
+.PHONY: build sandbox stop release clean
 
 build: $(BUILD)/$(RUN)
 
-DISPLAY_NO := 8
-XEPHYR := Xephyr :$(DISPLAY_NO) +extension RANDR -br -ac -noreset -screen 800x600
-
-test: build
-	$(XEPHYR) &
+sandbox: build
+	$(SANDBOX) &
 	# wait for x server to start
 	sleep 1
-	DISPLAY=:$(DISPLAY_NO) gdb -ex run ./$(BUILD)/$(RUN)
-
-test-multi: build
-	$(XEPHYR) -screen 800x600+800+0 &
-	# wait for x server to start
-	sleep 1
-	DISPLAY=:$(DISPLAY_NO) gdb -ex run ./$(BUILD)/$(RUN)
+	DISPLAY=:$(SANDBOX_DISPLAY) gdb -ex run ./$(BUILD)/$(RUN)
 
 stop:
 	pkill Xephyr

--- a/include/action.h
+++ b/include/action.h
@@ -15,8 +15,8 @@ typedef enum {
     ACTION_REMOVE_FRAME,
     /* changes a popup window to a tiling window and vise versa */
     ACTION_CHANGE_WINDOW_STATE,
-    /* changes from focusing a popup window to focusing a tiling window */
-    ACTION_CHANGE_FOCUS,
+    /* changes the window that was in focus before the current one */
+    ACTION_TRAVERSE_FOCUS,
     /* toggles the fullscreen state of the currently focused window */
     ACTION_TOGGLE_FULLSCREEN,
     /* split the current frame horizontally */

--- a/include/fensterchef.h
+++ b/include/fensterchef.h
@@ -27,16 +27,16 @@
 #define UTF8_TEXT(text) ((FcChar8*) (text))
 
 /* xcb server connection */
-extern xcb_connection_t         *g_dpy;
+extern xcb_connection_t         *connection;
 
 /* ewmh (extended window manager hints) information */
 extern xcb_ewmh_connection_t    ewmh;
 
-/* 1 while the window manager is running */
-extern bool                     g_running;
+/* true while the window manager is running */
+extern bool                     is_fensterchef_running;
 
 /* general purpose values */
-extern uint32_t                 g_values[7];
+extern uint32_t                 general_values[7];
 
 /* Initialize most of fensterchef data and set root window flags. */
 int init_fensterchef(int *screen_number);

--- a/include/frame.h
+++ b/include/frame.h
@@ -27,7 +27,7 @@ typedef struct frame {
 } Frame;
 
 /* the currently selected/focused frame */
-extern Frame *g_cur_frame;
+extern Frame *focus_frame;
 
 /* Check if the given point is within the given frame.
  *

--- a/include/log.h
+++ b/include/log.h
@@ -9,7 +9,7 @@
 #include <time.h>
 #include <xcb/xcb_event.h>
 
-extern FILE *g_log_file;
+extern FILE *log_file;
 
 /* Log a formatted message to the log file. */
 #define LOG(fmt, ...) do { \
@@ -19,13 +19,13 @@ extern FILE *g_log_file;
     cur_time = time(NULL); \
     tm = localtime(&cur_time); \
     strftime(buf, sizeof(buf), "[%F %T]", tm); \
-    fputs(buf, g_log_file); \
-    fprintf(g_log_file, "(%s:%d) ", __FILE__, __LINE__); \
-    fprintf(g_log_file, (fmt), ##__VA_ARGS__); \
+    fputs(buf, log_file); \
+    fprintf(log_file, "(%s:%d) ", __FILE__, __LINE__); \
+    fprintf(log_file, (fmt), ##__VA_ARGS__); \
 } while (0)
 
 #define LOG_ADDITIONAL(fmt, ...) do { \
-    fprintf(g_log_file, (fmt), ##__VA_ARGS__); \
+    fprintf(log_file, (fmt), ##__VA_ARGS__); \
 } while (0)
 
 /* Log a formatted message to the log file with error indication. */
@@ -36,9 +36,9 @@ extern FILE *g_log_file;
     cur_time = time(NULL); \
     tm = localtime(&cur_time); \
     strftime(buf, sizeof(buf), "{%F %T}", tm); \
-    fputs(buf, g_log_file); \
-    fprintf(g_log_file, "(%s:%d) ERR ", __FILE__, __LINE__); \
-    fprintf(g_log_file, (fmt), ##__VA_ARGS__); \
+    fputs(buf, log_file); \
+    fprintf(log_file, "(%s:%d) ERR ", __FILE__, __LINE__); \
+    fprintf(log_file, (fmt), ##__VA_ARGS__); \
 } while (0)
 
 /* Log an event to the log file.  */

--- a/include/screen.h
+++ b/include/screen.h
@@ -41,7 +41,7 @@ typedef struct screen {
 } Screen;
 
 /* the actively used screen */
-extern Screen *g_screen;
+extern Screen *screen;
 
 /* forward declaration */
 struct frame;

--- a/include/tiling.h
+++ b/include/tiling.h
@@ -5,11 +5,9 @@
 
 /* Split a frame horizontally or vertically. 
  *
- * The frame @split_from must have NO children.
- *
- * @is_split_vert 1 for a vertical split and 0 for a horizontal split.
+ * @is_split_vert true for a vertical split and false for a horizontal split.
  */
-void split_frame(Frame *split_from, int is_split_vert);
+void split_frame(Frame *split_from, bool is_split_vert);
 
 /* Remove a frame from the screen and hide the inner windows.
  *

--- a/include/window.h
+++ b/include/window.h
@@ -44,6 +44,17 @@ typedef struct window {
     /* the id of this window */
     uint32_t number;
 
+    /* the focus chain is a linked list containing only visible windows and
+     * their relative time when they were focused; the focus chain is cyclic,
+     * meaning that all windows within the focus chain have a next_focus and
+     * previous_focus
+     */
+
+    /* the previous window in the focus chain */
+    struct window *previous_focus;
+    /* the next window in the focus chain */
+    struct window *next_focus;
+
     /* the next window in the linked list */
     struct window *next;
 } Window;
@@ -51,7 +62,10 @@ typedef struct window {
 /* the first window in the linked list, the list is sorted increasingly
  * with respect to the window number
  */
-extern Window *g_first_window;
+extern Window *first_window;
+
+/* the currently focused window */
+extern Window *focus_window;
 
 /* Create a window struct and add it to the window list,
  * this also assigns the next id. */
@@ -89,20 +103,22 @@ Window *get_window_of_xcb_window(xcb_window_t xcb_window);
  */
 Frame *get_frame_of_window(const Window *window);
 
-/* Get the currently focused window.
- *
- * @return NULL when the root has focus.
- */
-Window *get_focus_window(void);
+/* Removes a window from the focus list. */
+void unlink_window_from_focus_list(Window *window);
 
-/* Set the window that is in focus.
- *
- * @return 1 if the window does not accept focus, 0 otherwise.
- */
-int set_focus_window(Window *window);
+/* Check if the window accepts input focus. */
+bool does_window_accept_focus(Window *window);
 
-/* Gives any window different from given window focus. */
-void give_someone_else_focus(Window *window);
+/* Set the window that is in focus. */
+void set_focus_window(Window *window);
+
+/* Focuses the window before or after the currently focused window. */
+void traverse_focus_chain(int direction);
+
+/* Focuses the window guaranteed but also focuse the frame of the window if it
+ * has one.
+ */
+void set_focus_window_with_frame(Window *window);
 
 /* Get a window that is not shown but in the window list coming after
  * the given window or NULL when there is none.

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -23,7 +23,7 @@ typedef struct window Window;
  */
 typedef struct window_state {
     /* if the window was ever mapped */
-    bool is_mappable;
+    bool was_ever_mapped;
     /* if the window is visible (mapped) */
     bool is_visible;
     /* if the window was forced to be a certain mode */
@@ -45,10 +45,26 @@ window_mode_t predict_window_mode(Window *window);
  */
 void set_window_mode(Window *window, window_mode_t mode, bool force_mode);
 
+/* Show given window but do not assign an id and no size configuring. */
+void show_window_quickly(Window *window);
+
 /* Show the window by positioning it and mapping it to the X server. */
 void show_window(Window *window);
 
-/* Hide the window by unmapping it to the X server. */
+/* Hide a window without focusing another window or filling the tiling gap.
+ *
+ * The caller must make sure to give another window focus if the given window is
+ * the focus window.
+ */
+void hide_window_quickly(Window *window);
+
+/* Hide the window by unmapping it from the X server.
+ *
+ * When the window is a tiling window, this places the next available window in
+ * the formed gap.
+ *
+ * The next window is focused.
+ */
 void hide_window(Window *window);
 
 #endif

--- a/src/keybind.c
+++ b/src/keybind.c
@@ -35,7 +35,7 @@ static struct {
     { MOD_KEY, XK_r, ACTION_REMOVE_FRAME },
 
     { MOD_KEY | XCB_MOD_MASK_SHIFT, XK_space, ACTION_CHANGE_WINDOW_STATE },
-    { MOD_KEY, XK_space, ACTION_CHANGE_FOCUS },
+    { MOD_KEY, XK_space, ACTION_TRAVERSE_FOCUS },
 
     { MOD_KEY, XK_f, ACTION_TOGGLE_FULLSCREEN },
 
@@ -62,10 +62,10 @@ void init_keybinds(void)
     };
     uint16_t modifiers;
 
-    root = g_screen->xcb_screen->root;
+    root = screen->xcb_screen->root;
 
     /* remove all previously grabbed keys so that we can overwrite them */
-    xcb_ungrab_key(g_dpy, XCB_GRAB_ANY, root, XCB_MOD_MASK_ANY);
+    xcb_ungrab_key(connection, XCB_GRAB_ANY, root, XCB_MOD_MASK_ANY);
 
     for (uint32_t i = 0; i < SIZE(key_binds); i++) {
         /* go over all keycodes of a specific key symbol and grab them with
@@ -88,7 +88,7 @@ void init_keybinds(void)
                     }
                 }
 
-                xcb_grab_key(g_dpy,
+                xcb_grab_key(connection,
                         1, /* 1 means we specify a specific window for grabbing */
                         root, /* this is the window we grab the key for */
                         modifiers, keycode[j],

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -3,13 +3,13 @@
 #include "keymap.h"
 
 /* symbol translation table */
-static xcb_key_symbols_t *keysyms;
+static xcb_key_symbols_t *key_symbols;
 
 /* Initializes the keymap so the below functions can be used. */
 int init_keymap(void)
 {
-    keysyms = xcb_key_symbols_alloc(g_dpy);
-    if (keysyms == NULL) {
+    key_symbols = xcb_key_symbols_alloc(connection);
+    if (key_symbols == NULL) {
         return 1;
     }
     return 0;
@@ -18,7 +18,7 @@ int init_keymap(void)
 /* Refresh the keymap if a mapping notify event arrives. */
 void refresh_keymap(xcb_mapping_notify_event_t *event)
 {
-    (void) xcb_refresh_keyboard_mapping(keysyms, event);
+    (void) xcb_refresh_keyboard_mapping(key_symbols, event);
     /* regrab all keys */
     init_keybinds();
 }
@@ -26,13 +26,11 @@ void refresh_keymap(xcb_mapping_notify_event_t *event)
 /* Get a keysym from a keycode. */
 xcb_keysym_t get_keysym(xcb_keycode_t keycode)
 {
-    return xcb_key_symbols_get_keysym(keysyms, keycode, 0);
+    return xcb_key_symbols_get_keysym(key_symbols, keycode, 0);
 }
 
-/* Get a list of keycodes from a keysym.
- * The caller needs to free this list.
- */
+/* Get a list of keycodes from a keysym. */
 xcb_keycode_t *get_keycodes(xcb_keysym_t keysym)
 {
-    return xcb_key_symbols_get_keycode(keysyms, keysym);
+    return xcb_key_symbols_get_keycode(key_symbols, keysym);
 }

--- a/src/log.c
+++ b/src/log.c
@@ -8,7 +8,7 @@
 #include "util.h"
 
 /* the file to log to */
-FILE *g_log_file;
+FILE *log_file;
 
 /* Log key modifiers to the log file. */
 static void log_modifiers(uint32_t mask)
@@ -24,9 +24,9 @@ static void log_modifiers(uint32_t mask)
             modifier++) {
         if ((mask & 1)) {
             if (mod_count > 0) {
-                fprintf(g_log_file, "+");
+                fprintf(log_file, "+");
             }
-            fprintf(g_log_file, *modifier);
+            fprintf(log_file, *modifier);
             mod_count++;
         }
     }
@@ -90,21 +90,21 @@ void log_event(xcb_generic_event_t *event)
 
     LOG("");
     event_type = (event->response_type & ~0x80);
-    fputs(xcb_event_get_label(event_type), g_log_file);
+    fputs(xcb_event_get_label(event_type), log_file);
     if (event_type == XCB_GE_GENERIC) {
         gen = (xcb_ge_generic_event_t*) event;
         if (gen->extension >= SIZE(generic_event_strings)) {
-            fprintf(g_log_file, "UNKNOWN_EVENT[%" PRIu8 "]", event_type);
+            fprintf(log_file, "UNKNOWN_EVENT[%" PRIu8 "]", event_type);
         } else {
-            fprintf(g_log_file, "%s", generic_event_strings[gen->extension]);
+            fprintf(log_file, "%s", generic_event_strings[gen->extension]);
         }
     }
 
-    fputc('(', g_log_file);
+    fputc('(', log_file);
     switch (event_type) {
     case 0:
         error = (xcb_generic_error_t*) event;
-        fprintf(g_log_file, "label=%s, code=%" PRIu8 ", sequence=%" PRIu16 ", major=%" PRIu8 ", minor=%" PRIu16,
+        fprintf(log_file, "label=%s, code=%" PRIu8 ", sequence=%" PRIu16 ", major=%" PRIu8 ", minor=%" PRIu16,
                 xcb_event_get_error_label(error->error_code),
                 error->error_code, error->sequence, error->major_code,
                 error->minor_code);
@@ -113,7 +113,7 @@ void log_event(xcb_generic_event_t *event)
     case XCB_KEY_PRESS:
     case XCB_KEY_RELEASE:
         kp = (xcb_key_press_event_t*) event;
-        fprintf(g_log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", mod=",
+        fprintf(log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", mod=",
                 kp->time, kp->root, kp->event, kp->child, kp->detail);
         log_modifiers(kp->state);
         break;
@@ -121,14 +121,14 @@ void log_event(xcb_generic_event_t *event)
     case XCB_BUTTON_PRESS:
     case XCB_BUTTON_RELEASE:
         bp = (xcb_button_press_event_t*) event;
-        fprintf(g_log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", mod=",
+        fprintf(log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", mod=",
                 bp->time, bp->root, bp->event, bp->child, bp->detail);
         log_modifiers(bp->state);
         break;
 
     case XCB_MOTION_NOTIFY:
         mn = (xcb_motion_notify_event_t*) event;
-        fprintf(g_log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16 ", mod=",
+        fprintf(log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16 ", mod=",
                 mn->time, mn->root, mn->event, mn->child, mn->detail, mn->root_x, mn->root_y, mn->event_x, mn->event_y);
         log_modifiers(mn->state);
         break;
@@ -136,149 +136,149 @@ void log_event(xcb_generic_event_t *event)
     case XCB_ENTER_NOTIFY:
     case XCB_LEAVE_NOTIFY:
         en = (xcb_enter_notify_event_t*) event;
-        fprintf(g_log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16,
+        fprintf(log_file, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16,
                 en->time, en->root, en->event, en->child, en->root_x, en->root_y, en->event_x, en->event_y);
         break;
 
     case XCB_FOCUS_IN:
     case XCB_FOCUS_OUT:
         fi = (xcb_focus_in_event_t*) event;
-        fprintf(g_log_file, "mode=%" PRIu8 ", detail=%" PRIu8 ", event=%" PRIu32, fi->mode, fi->detail, fi->event);
+        fprintf(log_file, "mode=%" PRIu8 ", detail=%" PRIu8 ", event=%" PRIu32, fi->mode, fi->detail, fi->event);
         break;
 
     case XCB_KEYMAP_NOTIFY:
         kn = (xcb_keymap_notify_event_t*) event;
         (void) kn;
-        fprintf(g_log_file, "keys=..."); // Keymap is a large array; implement if needed
+        fprintf(log_file, "keys=..."); // Keymap is a large array; implement if needed
         break;
 
     case XCB_EXPOSE:
         e = (xcb_expose_event_t*) event;
-        fprintf(g_log_file, "x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16,
+        fprintf(log_file, "x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16,
                 e->x, e->y, e->width, e->height, e->count);
         break;
 
     case XCB_GRAPHICS_EXPOSURE:
         ge = (xcb_graphics_exposure_event_t*) event;
-        fprintf(g_log_file, "x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
+        fprintf(log_file, "x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
                 ge->x, ge->y, ge->width, ge->height, ge->count, ge->minor_opcode, ge->major_opcode);
         break;
 
     case XCB_NO_EXPOSURE:
         ne = (xcb_no_exposure_event_t*) event;
-        fprintf(g_log_file, "sequence=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
+        fprintf(log_file, "sequence=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
                 ne->sequence, ne->minor_opcode, ne->major_opcode);
         break;
 
     case XCB_VISIBILITY_NOTIFY:
         vn = (xcb_visibility_notify_event_t*) event;
-        fprintf(g_log_file, "state=%" PRIu8, vn->state);
+        fprintf(log_file, "state=%" PRIu8, vn->state);
         break;
 
     case XCB_CREATE_NOTIFY:
         crn = (xcb_create_notify_event_t*) event;
-        fprintf(g_log_file, "parent=%" PRIu32 ", window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(log_file, "parent=%" PRIu32 ", window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
                 crn->parent, crn->window, crn->x, crn->y, crn->width, crn->height);
         break;
 
     case XCB_DESTROY_NOTIFY:
         dn = (xcb_destroy_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32, dn->window);
+        fprintf(log_file, "window=%" PRIu32, dn->window);
         break;
 
     case XCB_UNMAP_NOTIFY:
         un = (xcb_unmap_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", from_configure=%" PRIu8,
+        fprintf(log_file, "window=%" PRIu32 ", from_configure=%" PRIu8,
                 un->window, un->from_configure);
         break;
 
     case XCB_MAP_NOTIFY:
         man = (xcb_map_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", override_redirect=%" PRIu8,
+        fprintf(log_file, "window=%" PRIu32 ", override_redirect=%" PRIu8,
                 man->window, man->override_redirect);
         break;
 
     case XCB_MAP_REQUEST:
         mr = (xcb_map_request_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", parent=%" PRIu32,
+        fprintf(log_file, "window=%" PRIu32 ", parent=%" PRIu32,
                 mr->window, mr->parent);
         break;
 
     case XCB_REPARENT_NOTIFY:
         rn = (xcb_reparent_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", parent=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
+        fprintf(log_file, "window=%" PRIu32 ", parent=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
                 rn->window, rn->parent, rn->x, rn->y);
         break;
 
     case XCB_CONFIGURE_NOTIFY:
         cn = (xcb_configure_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(log_file, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
                 cn->window, cn->x, cn->y, cn->width, cn->height);
         break;
 
     case XCB_CONFIGURE_REQUEST:
         cr = (xcb_configure_request_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(log_file, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
                 cr->window, cr->x, cr->y, cr->width, cr->height);
         break;
 
     case XCB_GRAVITY_NOTIFY:
         gn = (xcb_gravity_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
+        fprintf(log_file, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
                 gn->window, gn->x, gn->y);
         break;
 
     case XCB_RESIZE_REQUEST:
         rr = (xcb_resize_request_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(log_file, "window=%" PRIu32 ", width=%" PRIu16 ", height=%" PRIu16,
                 rr->window, rr->width, rr->height);
         break;
 
     case XCB_CIRCULATE_NOTIFY:
         cin = (xcb_circulate_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", place=%" PRIu8,
+        fprintf(log_file, "window=%" PRIu32 ", place=%" PRIu8,
                 cin->window, cin->place);
         break;
 
     case XCB_CIRCULATE_REQUEST:
         cir = (xcb_circulate_request_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", place=%" PRIu8,
+        fprintf(log_file, "window=%" PRIu32 ", place=%" PRIu8,
                 cir->window, cir->place);
         break;
 
     case XCB_PROPERTY_NOTIFY:
         pn = (xcb_property_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", atom=%" PRIu32 ", time=%" PRIu32 ", state=%" PRIu8,
+        fprintf(log_file, "window=%" PRIu32 ", atom=%" PRIu32 ", time=%" PRIu32 ", state=%" PRIu8,
                 pn->window, pn->atom, pn->time, pn->state);
         break;
 
     case XCB_SELECTION_CLEAR:
         sc = (xcb_selection_clear_event_t*) event;
-        fprintf(g_log_file, "owner=%" PRIu32 ", selection=%" PRIu32 ", time=%" PRIu32,
+        fprintf(log_file, "owner=%" PRIu32 ", selection=%" PRIu32 ", time=%" PRIu32,
                 sc->owner, sc->selection, sc->time);
         break;
 
     case XCB_SELECTION_REQUEST:
         sr = (xcb_selection_request_event_t*) event;
-        fprintf(g_log_file, "owner=%" PRIu32 ", requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32,
+        fprintf(log_file, "owner=%" PRIu32 ", requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32,
                 sr->owner, sr->requestor, sr->selection, sr->target);
         break;
 
     case XCB_SELECTION_NOTIFY:
         sn = (xcb_selection_notify_event_t*) event;
-        fprintf(g_log_file, "requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32 ", property=%" PRIu32 ", time=%" PRIu32,
+        fprintf(log_file, "requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32 ", property=%" PRIu32 ", time=%" PRIu32,
                 sn->requestor, sn->selection, sn->target, sn->property, sn->time);
         break;
 
     case XCB_COLORMAP_NOTIFY:
         con = (xcb_colormap_notify_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", colormap=%" PRIu32 ", new=%" PRIu8 ", state=%" PRIu8,
+        fprintf(log_file, "window=%" PRIu32 ", colormap=%" PRIu32 ", new=%" PRIu8 ", state=%" PRIu8,
                 con->window, con->colormap, con->_new, con->state);
         break;
 
     case XCB_CLIENT_MESSAGE:
         cln = (xcb_client_message_event_t*) event;
-        fprintf(g_log_file, "window=%" PRIu32 ", type=%" PRIu32
+        fprintf(log_file, "window=%" PRIu32 ", type=%" PRIu32
                 ", data=%" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32,
                 cln->window, cln->type, cln->data.data32[0], cln->data.data32[1],
                 cln->data.data32[2], cln->data.data32[3], cln->data.data32[4]);
@@ -286,17 +286,17 @@ void log_event(xcb_generic_event_t *event)
 
     case XCB_MAPPING_NOTIFY:
         min = (xcb_mapping_notify_event_t*) event;
-        fprintf(g_log_file, "request=%" PRIu8 ", first_keycode=%" PRIu8 ", count=%" PRIu8,
+        fprintf(log_file, "request=%" PRIu8 ", first_keycode=%" PRIu8 ", count=%" PRIu8,
                 min->request, min->first_keycode, min->count);
         break;
 
     case XCB_GE_GENERIC:
         gen = (xcb_ge_generic_event_t*) event;
-        fprintf(g_log_file, "sequence=%" PRIu16 ", length=%" PRIu32,
+        fprintf(log_file, "sequence=%" PRIu16 ", length=%" PRIu32,
                 gen->sequence, gen->length);
         break;
     }
-    fputs(")\n", g_log_file);
+    fputs(")\n", log_file);
 }
 
 /* Log an xcb error to the log file with additional output formatting and new
@@ -310,16 +310,16 @@ void log_error(xcb_generic_error_t *error, const char *fmt, ...)
     ERR("");
 
     va_start(list, fmt);
-    vfprintf(g_log_file, fmt, list);
+    vfprintf(log_file, fmt, list);
     va_end(list);
 
     error_label = xcb_event_get_error_label(error->error_code);
     if (error_label != NULL) {
-        fprintf(g_log_file, "X11 error: %s", error_label);
+        fprintf(log_file, "X11 error: %s", error_label);
     } else {
-        fprintf(g_log_file, "Unknown X11 error: ");
+        fprintf(log_file, "Unknown X11 error: ");
     }
-    fprintf(g_log_file, "(code=%d, sequence=%d, major=%d, minor=%d)\n",
+    fprintf(log_file, "(code=%d, sequence=%d, major=%d, minor=%d)\n",
             error->error_code, error->sequence, error->major_code,
             error->minor_code);
 }
@@ -328,11 +328,11 @@ void log_error(xcb_generic_error_t *error, const char *fmt, ...)
 void log_screen(void)
 {
     LOG("Screen with root %u(width=%u, height=%u, white_pixel=%u, black_pixel=%u)\n",
-            g_screen->xcb_screen->root,
-            g_screen->xcb_screen->width_in_pixels,
-            g_screen->xcb_screen->height_in_pixels,
-            g_screen->xcb_screen->white_pixel,
-            g_screen->xcb_screen->black_pixel);
+            screen->xcb_screen->root,
+            screen->xcb_screen->width_in_pixels,
+            screen->xcb_screen->height_in_pixels,
+            screen->xcb_screen->white_pixel,
+            screen->xcb_screen->black_pixel);
 }
 
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -37,18 +37,18 @@ int main(void)
 
     synchronize_all_root_properties();
 
-    g_cur_frame = get_primary_monitor()->frame;
+    focus_frame = get_primary_monitor()->frame;
 
-    g_running = true;
-    while (g_running) {
-        if (xcb_connection_has_error(g_dpy) > 0) {
+    is_fensterchef_running = true;
+    while (is_fensterchef_running) {
+        if (xcb_connection_has_error(connection) > 0) {
             quit_fensterchef(EXIT_FAILURE);
         }
-        event = xcb_wait_for_event(g_dpy);
+        event = xcb_wait_for_event(connection);
         if (event != NULL) {
             handle_event(event);
             free(event);
-            xcb_flush(g_dpy);
+            xcb_flush(connection);
         }
     }
 

--- a/src/root_properties.c
+++ b/src/root_properties.c
@@ -93,7 +93,7 @@ static void synchronize_supported(void)
         XCB_ATOM_WM_TRANSIENT_FOR,
     };
 
-    xcb_ewmh_set_supported(&ewmh, g_screen->number, SIZE(supported_atoms),
+    xcb_ewmh_set_supported(&ewmh, screen->number, SIZE(supported_atoms),
             /* xcb_ewmh_set_supported() expects a non const value, however, it
              * is just passed into a function expecting a const value
              */
@@ -112,7 +112,7 @@ static void synchronize_work_area(void)
     top = 0;
     right = 0;
     bottom = 0;
-    for (Window *window = g_first_window; window != NULL;
+    for (Window *window = first_window; window != NULL;
             window = window->next) {
         left += window->properties.struts.left;
         top += window->properties.struts.top;
@@ -121,9 +121,9 @@ static void synchronize_work_area(void)
     }
     geometry.x = left;
     geometry.y = top;
-    geometry.width = g_screen->xcb_screen->width_in_pixels - right - left;
-    geometry.height = g_screen->xcb_screen->height_in_pixels - bottom - top;
-    xcb_ewmh_set_workarea(&ewmh, g_screen->number, 1, &geometry);
+    geometry.width = screen->xcb_screen->width_in_pixels - right - left;
+    geometry.height = screen->xcb_screen->height_in_pixels - bottom - top;
+    xcb_ewmh_set_workarea(&ewmh, screen->number, 1, &geometry);
 }
 
 /* Synchronize a root property with the X property. */
@@ -132,7 +132,6 @@ void synchronize_root_property(root_property_t property)
     static const char *desktop_name = "0: only desktop";
 
     xcb_ewmh_coordinates_t coordinate;
-    Window *focus;
 
     switch (property) {
     /* the supported options of our window manager */
@@ -142,40 +141,39 @@ void synchronize_root_property(root_property_t property)
 
     /* the number of desktops, just set it to 1 */
     case ROOT_PROPERTY_NUMBER_OF_DESKTOPS:
-        xcb_ewmh_set_number_of_desktops(&ewmh, g_screen->number, 1);
+        xcb_ewmh_set_number_of_desktops(&ewmh, screen->number, 1);
         break;
 
     /* the size of a desktop, we do not support large desktops */
     case ROOT_PROPERTY_DESKTOP_GEOMETRY:
-        xcb_ewmh_set_desktop_geometry(&ewmh, g_screen->number,
-                g_screen->xcb_screen->width_in_pixels,
-                g_screen->xcb_screen->height_in_pixels);
+        xcb_ewmh_set_desktop_geometry(&ewmh, screen->number,
+                screen->xcb_screen->width_in_pixels,
+                screen->xcb_screen->height_in_pixels);
         break;
 
     /* viewport of each desktop, just set it to (0, 0) for the only desktop */
     case ROOT_PROPERTY_DESKTOP_VIEWPORT:
         coordinate.x = 0;
         coordinate.y = 0;
-        xcb_ewmh_set_desktop_viewport(&ewmh, g_screen->number, 1,
+        xcb_ewmh_set_desktop_viewport(&ewmh, screen->number, 1,
                 &coordinate);
         break;
 
     /* the currently selected desktop, always 0 */
     case ROOT_PROPERTY_CURRENT_DESKTOP:
-        xcb_ewmh_set_current_desktop(&ewmh, g_screen->number, 0);
+        xcb_ewmh_set_current_desktop(&ewmh, screen->number, 0);
         break;
 
     /* the name of each desktop */
     case ROOT_PROPERTY_DESKTOP_NAMES:
-        xcb_ewmh_set_desktop_names(&ewmh, g_screen->number,
+        xcb_ewmh_set_desktop_names(&ewmh, screen->number,
                 strlen(desktop_name), desktop_name);
         break;
 
     /* the currently active window */
     case ROOT_PROPERTY_ACTIVE_WINDOW:
-        focus = get_focus_window();
-        xcb_ewmh_set_active_window(&ewmh, g_screen->number, focus == NULL ?
-                g_screen->xcb_screen->root : focus->xcb_window);
+        xcb_ewmh_set_active_window(&ewmh, screen->number, focus_window == NULL ?
+                screen->xcb_screen->root : focus_window->xcb_window);
         break;
 
     /* the work area (screen space minus struts) */
@@ -187,8 +185,8 @@ void synchronize_root_property(root_property_t property)
      * mangager
      */
     case ROOT_PROPERTY_SUPPORTING_WM_CHECK:
-        xcb_ewmh_set_supporting_wm_check(&ewmh, g_screen->xcb_screen->root,
-                g_screen->check_window);
+        xcb_ewmh_set_supporting_wm_check(&ewmh, screen->xcb_screen->root,
+                screen->check_window);
         break;
 
     /* not a real property */

--- a/src/screen.c
+++ b/src/screen.c
@@ -29,7 +29,7 @@
 static bool randr_enabled = false;
 
 /* the actively used screen */
-Screen *g_screen;
+Screen *screen;
 
 /* Initializes the stock_objects array with graphical objects. */
 static inline int init_stock_objects(void)
@@ -42,47 +42,47 @@ static inline int init_stock_objects(void)
     xcb_pixmap_t                                pixmap;
     xcb_rectangle_t                             rect;
 
-    root = g_screen->xcb_screen->root;
+    root = screen->xcb_screen->root;
 
     for (uint32_t i = 0; i < STOCK_COUNT; i++) {
-        g_screen->stock_objects[i] = xcb_generate_id(g_dpy);
+        screen->stock_objects[i] = xcb_generate_id(connection);
     }
 
-    g_values[0] = g_screen->xcb_screen->black_pixel;
-    g_values[1] = g_screen->xcb_screen->white_pixel;
-    error = xcb_request_check(g_dpy,
-            xcb_create_gc_checked(g_dpy, g_screen->stock_objects[STOCK_GC],
+    general_values[0] = screen->xcb_screen->black_pixel;
+    general_values[1] = screen->xcb_screen->white_pixel;
+    error = xcb_request_check(connection,
+            xcb_create_gc_checked(connection, screen->stock_objects[STOCK_GC],
                 root,
-                XCB_GC_FOREGROUND | XCB_GC_BACKGROUND, g_values));
+                XCB_GC_FOREGROUND | XCB_GC_BACKGROUND, general_values));
     if (error != NULL) {
         log_error(error, "could not create graphics context for notifications: ");
         return 1;
     }
 
-    g_values[0] = g_screen->xcb_screen->white_pixel;
-    g_values[1] = g_screen->xcb_screen->black_pixel;
-    error = xcb_request_check(g_dpy,
-            xcb_create_gc_checked(g_dpy, g_screen->stock_objects[STOCK_INVERTED_GC],
-                root,
-                XCB_GC_FOREGROUND | XCB_GC_BACKGROUND, g_values));
+    general_values[0] = screen->xcb_screen->white_pixel;
+    general_values[1] = screen->xcb_screen->black_pixel;
+    error = xcb_request_check(connection,
+            xcb_create_gc_checked(connection,
+                screen->stock_objects[STOCK_INVERTED_GC], root,
+                XCB_GC_FOREGROUND | XCB_GC_BACKGROUND, general_values));
     if (error != NULL) {
         log_error(error, "could not create inverted graphics context for notifications: ");
         return 1;
     }
 
-    fmt_reply = xcb_render_util_query_formats(g_dpy);
+    fmt_reply = xcb_render_util_query_formats(connection);
 
     fmt = xcb_render_util_find_standard_format(fmt_reply,
             XCB_PICT_STANDARD_ARGB_32);
 
     /* create white pen */
-    pixmap = xcb_generate_id(g_dpy);
-    xcb_create_pixmap(g_dpy, 32, pixmap, root, 1, 1);
+    pixmap = xcb_generate_id(connection);
+    xcb_create_pixmap(connection, 32, pixmap, root, 1, 1);
 
-    g_values[0] = XCB_RENDER_REPEAT_NORMAL;
-    xcb_render_create_picture(g_dpy, g_screen->stock_objects[STOCK_WHITE_PEN],
-            pixmap, fmt->id,
-            XCB_RENDER_CP_REPEAT, g_values);
+    general_values[0] = XCB_RENDER_REPEAT_NORMAL;
+    xcb_render_create_picture(connection,
+            screen->stock_objects[STOCK_WHITE_PEN], pixmap, fmt->id,
+            XCB_RENDER_CP_REPEAT, general_values);
 
     rect.x = 0;
     rect.y = 0;
@@ -93,27 +93,27 @@ static inline int init_stock_objects(void)
     color.red = 0xff00;
     color.green = 0xff00;
     color.blue = 0xff00;
-    xcb_render_fill_rectangles(g_dpy, XCB_RENDER_PICT_OP_OVER,
-            g_screen->stock_objects[STOCK_WHITE_PEN], color, 1, &rect);
+    xcb_render_fill_rectangles(connection, XCB_RENDER_PICT_OP_OVER,
+            screen->stock_objects[STOCK_WHITE_PEN], color, 1, &rect);
 
-    xcb_free_pixmap(g_dpy, pixmap);
+    xcb_free_pixmap(connection, pixmap);
 
     /* create black pen */
-    pixmap = xcb_generate_id(g_dpy);
-    xcb_create_pixmap(g_dpy, 32, pixmap, root, 1, 1);
+    pixmap = xcb_generate_id(connection);
+    xcb_create_pixmap(connection, 32, pixmap, root, 1, 1);
 
-    g_values[0] = XCB_RENDER_REPEAT_NORMAL;
-    xcb_render_create_picture(g_dpy, g_screen->stock_objects[STOCK_BLACK_PEN],
+    general_values[0] = XCB_RENDER_REPEAT_NORMAL;
+    xcb_render_create_picture(connection, screen->stock_objects[STOCK_BLACK_PEN],
             pixmap, fmt->id,
-            XCB_RENDER_CP_REPEAT, g_values);
+            XCB_RENDER_CP_REPEAT, general_values);
 
     color.red = 0x0000;
     color.green = 0x0000;
     color.blue = 0x0000;
-    xcb_render_fill_rectangles(g_dpy, XCB_RENDER_PICT_OP_OVER,
-            g_screen->stock_objects[STOCK_BLACK_PEN], color, 1, &rect);
+    xcb_render_fill_rectangles(connection, XCB_RENDER_PICT_OP_OVER,
+            screen->stock_objects[STOCK_BLACK_PEN], color, 1, &rect);
 
-    xcb_free_pixmap(g_dpy, pixmap);
+    xcb_free_pixmap(connection, pixmap);
 
     return 0;
 }
@@ -123,12 +123,16 @@ static inline int create_utility_windows(void)
 {
     xcb_window_t root;
     xcb_generic_error_t *error;
+    xcb_icccm_wm_hints_t no_input_hints;
 
-    root = g_screen->xcb_screen->root;
+    root = screen->xcb_screen->root;
 
-    g_screen->check_window = xcb_generate_id(g_dpy);
-    error = xcb_request_check(g_dpy, xcb_create_window_checked(g_dpy,
-                XCB_COPY_FROM_PARENT, g_screen->check_window,
+    no_input_hints.flags = XCB_ICCCM_WM_HINT_INPUT;
+    no_input_hints.input = 0;
+
+    screen->check_window = xcb_generate_id(connection);
+    error = xcb_request_check(connection, xcb_create_window_checked(connection,
+                XCB_COPY_FROM_PARENT, screen->check_window,
                 root, -1, -1, 1, 1, 0,
                 XCB_WINDOW_CLASS_COPY_FROM_PARENT, XCB_COPY_FROM_PARENT,
                 0, NULL));
@@ -136,31 +140,33 @@ static inline int create_utility_windows(void)
         log_error(error, "could not create check window: ");
         return 1;
     }
-    xcb_ewmh_set_wm_name(&ewmh, g_screen->check_window,
+    xcb_ewmh_set_wm_name(&ewmh, screen->check_window,
             strlen(FENSTERCHEF_NAME), FENSTERCHEF_NAME);
-    xcb_ewmh_set_supporting_wm_check(&ewmh, g_screen->check_window,
-            g_screen->check_window);
+    xcb_ewmh_set_supporting_wm_check(&ewmh, screen->check_window,
+            screen->check_window);
 
-    g_screen->notification_window = xcb_generate_id(g_dpy);
-    g_values[0] = 0x000000;
-    error = xcb_request_check(g_dpy, xcb_create_window_checked(g_dpy,
-                XCB_COPY_FROM_PARENT, g_screen->notification_window,
+    screen->notification_window = xcb_generate_id(connection);
+    general_values[0] = 0x000000;
+    error = xcb_request_check(connection, xcb_create_window_checked(connection,
+                XCB_COPY_FROM_PARENT, screen->notification_window,
                 root, -1, -1, 1, 1, 0,
                 XCB_WINDOW_CLASS_COPY_FROM_PARENT, XCB_COPY_FROM_PARENT,
-                XCB_CW_BORDER_PIXEL, g_values));
+                XCB_CW_BORDER_PIXEL, general_values));
     if (error != NULL) {
         log_error(error, "could not create notification window: ");
         return 1;
     }
+    xcb_icccm_set_wm_hints(connection, screen->notification_window,
+            &no_input_hints);
 
-    g_screen->window_list_window = xcb_generate_id(g_dpy);
-    g_values[0] = 0x000000;
-    g_values[1] = XCB_EVENT_MASK_KEY_PRESS;
-    error = xcb_request_check(g_dpy, xcb_create_window_checked(g_dpy,
-                XCB_COPY_FROM_PARENT, g_screen->window_list_window,
+    screen->window_list_window = xcb_generate_id(connection);
+    general_values[0] = 0x000000;
+    general_values[1] = XCB_EVENT_MASK_KEY_PRESS;
+    error = xcb_request_check(connection, xcb_create_window_checked(connection,
+                XCB_COPY_FROM_PARENT, screen->window_list_window,
                 root, -1, -1, 1, 1, 0,
                 XCB_WINDOW_CLASS_COPY_FROM_PARENT, XCB_COPY_FROM_PARENT,
-                XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK, g_values));
+                XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK, general_values));
     if (error != NULL) {
         log_error(error, "could not create window list window: ");
         return 1;
@@ -174,20 +180,20 @@ int init_screen(int screen_number)
     xcb_window_t root;
     xcb_generic_error_t *error;
 
-    g_screen = xcalloc(1, sizeof(*g_screen));
-    g_screen->number = screen_number;
-    g_screen->xcb_screen = ewmh.screens[screen_number];
+    screen = xcalloc(1, sizeof(*screen));
+    screen->number = screen_number;
+    screen->xcb_screen = ewmh.screens[screen_number];
 
-    root = g_screen->xcb_screen->root;
+    root = screen->xcb_screen->root;
 
     if (init_stock_objects() != 0) {
         return 1;
     }
 
-    g_values[0] = ROOT_EVENT_MASK;
-    error = xcb_request_check(g_dpy,
-            xcb_change_window_attributes_checked(g_dpy, root,
-                XCB_CW_EVENT_MASK, g_values));
+    general_values[0] = ROOT_EVENT_MASK;
+    error = xcb_request_check(connection,
+            xcb_change_window_attributes_checked(connection, root,
+                XCB_CW_EVENT_MASK, general_values));
     if (error != NULL) {
         log_error(error, "could not change root window mask: ");
         return 1;
@@ -198,7 +204,7 @@ int init_screen(int screen_number)
     }
 
     /* grabs ALT+Button for moving popup windows */
-    xcb_grab_button(g_dpy, 0, root, XCB_EVENT_MASK_BUTTON_PRESS |
+    xcb_grab_button(connection, 0, root, XCB_EVENT_MASK_BUTTON_PRESS |
             XCB_EVENT_MASK_BUTTON_RELEASE, XCB_GRAB_MODE_ASYNC,
             XCB_GRAB_MODE_ASYNC, root, XCB_NONE, 1, XCB_MOD_MASK_1);
     return 0;
@@ -225,14 +231,14 @@ void init_monitors(void)
     xcb_randr_query_version_cookie_t version_cookie;
     xcb_randr_query_version_reply_t *version;
 
-    extension = xcb_get_extension_data(g_dpy, &xcb_randr_id);
+    extension = xcb_get_extension_data(connection, &xcb_randr_id);
     if (!extension->present) {
         return;
     }
 
-    version_cookie = xcb_randr_query_version(g_dpy, XCB_RANDR_MAJOR_VERSION,
+    version_cookie = xcb_randr_query_version(connection, XCB_RANDR_MAJOR_VERSION,
             XCB_RANDR_MINOR_VERSION);
-    version = xcb_randr_query_version_reply(g_dpy, version_cookie, &error);
+    version = xcb_randr_query_version_reply(connection, version_cookie, &error);
     if (error != NULL) {
         log_error(error, "could not query randr version: ");
         free(error);
@@ -244,7 +250,7 @@ void init_monitors(void)
     }
 
     if (randr_enabled) {
-        xcb_randr_select_input(g_dpy, g_screen->xcb_screen->root,
+        xcb_randr_select_input(connection, screen->xcb_screen->root,
                 XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE |
                 XCB_RANDR_NOTIFY_MASK_OUTPUT_CHANGE |
                 XCB_RANDR_NOTIFY_MASK_CRTC_CHANGE |
@@ -259,13 +265,13 @@ void init_monitors(void)
  */
 Monitor *get_primary_monitor(void)
 {
-    for (Monitor *monitor = g_screen->monitor; monitor != NULL;
+    for (Monitor *monitor = screen->monitor; monitor != NULL;
             monitor = monitor->next) {
         if (monitor->primary) {
             return monitor;
         }
     }
-    return g_screen->monitor;
+    return screen->monitor;
 }
 
 /* Get the monitor that overlaps given rectangle the most. */
@@ -276,7 +282,7 @@ Monitor *get_monitor_from_rectangle(int32_t x, int32_t y,
     uint64_t best_area = 0, area;
     int32_t x_overlap, y_overlap;
 
-    for (Monitor *monitor = g_screen->monitor; monitor != NULL;
+    for (Monitor *monitor = screen->monitor; monitor != NULL;
             monitor = monitor->next) {
         x_overlap = MIN(x + width,
                 monitor->position.x + monitor->size.width);
@@ -346,11 +352,11 @@ Monitor *query_monitors(void)
         return NULL;
     }
 
-    primary_cookie = xcb_randr_get_output_primary(g_dpy, g_screen->xcb_screen->root);
-    resources_cookie = xcb_randr_get_screen_resources_current(g_dpy,
-            g_screen->xcb_screen->root);
+    primary_cookie = xcb_randr_get_output_primary(connection, screen->xcb_screen->root);
+    resources_cookie = xcb_randr_get_screen_resources_current(connection,
+            screen->xcb_screen->root);
 
-    primary = xcb_randr_get_output_primary_reply(g_dpy, primary_cookie, NULL);
+    primary = xcb_randr_get_output_primary_reply(connection, primary_cookie, NULL);
     if (primary == NULL) {
         primary_output = XCB_NONE;
     } else {
@@ -358,7 +364,7 @@ Monitor *query_monitors(void)
         free(primary);
     }
 
-    resources = xcb_randr_get_screen_resources_current_reply(g_dpy,
+    resources = xcb_randr_get_screen_resources_current_reply(connection,
             resources_cookie, &error);
     if (error != NULL) {
         log_error(error, "could not get screen resources: ");
@@ -373,9 +379,9 @@ Monitor *query_monitors(void)
     first_monitor = NULL;
 
     for (int i = 0; i < output_count; i++) {
-        output_cookie = xcb_randr_get_output_info(g_dpy, outputs[i],
+        output_cookie = xcb_randr_get_output_info(connection, outputs[i],
                resources->timestamp);
-        output = xcb_randr_get_output_info_reply(g_dpy, output_cookie, &error);
+        output = xcb_randr_get_output_info_reply(connection, output_cookie, &error);
         if (error != NULL) {
             log_error(error, "unable to get output info of %d: ", i);
             free(error);
@@ -395,9 +401,9 @@ Monitor *query_monitors(void)
             continue;
         }
 
-        crtc_cookie = xcb_randr_get_crtc_info(g_dpy, output->crtc,
+        crtc_cookie = xcb_randr_get_crtc_info(connection, output->crtc,
                 resources->timestamp);
-        crtc = xcb_randr_get_crtc_info_reply(g_dpy, crtc_cookie, &error);
+        crtc = xcb_randr_get_crtc_info_reply(connection, crtc_cookie, &error);
         if (crtc == NULL) {
             log_error(error, "output: '%.*s' gave a NULL crtc?? ", name_len, name);
             free(error);
@@ -429,7 +435,7 @@ void reconfigure_monitor_frame_sizes(void)
     Monitor *monitor;
 
     /* reset all extents */
-    for (monitor = g_screen->monitor; monitor != NULL;
+    for (monitor = screen->monitor; monitor != NULL;
             monitor = monitor->next) {
         monitor->struts.left = 0;
         monitor->struts.top = 0;
@@ -438,7 +444,7 @@ void reconfigure_monitor_frame_sizes(void)
     }
 
     /* work out the new extents based on the window defined extents */
-    for (Window *window = g_first_window; window != NULL;
+    for (Window *window = first_window; window != NULL;
             window = window->next) {
         if (!window->state.is_visible ||
                 is_strut_empty(&window->properties.struts)) {
@@ -453,7 +459,7 @@ void reconfigure_monitor_frame_sizes(void)
     }
 
     /* resize all frames to their according size */
-    for (monitor = g_screen->monitor; monitor != NULL;
+    for (monitor = screen->monitor; monitor != NULL;
             monitor = monitor->next) {
         resize_frame(monitor->frame,
                 monitor->position.x + monitor->struts.left,
@@ -468,7 +474,7 @@ void reconfigure_monitor_frame_sizes(void)
 /* Merges given monitor linked list into the screen.
  *
  * The main purpose of this function is to essentially make the linked in screen
- * be @monitors, but it is not enough to say: `g_screen->monitor = monitors`.
+ * be @monitors, but it is not enough to say: `screen->monitor = monitors`.
  *
  * The current rule is to keep monitors from the source and delete monitors no
  * longer in the list.
@@ -479,14 +485,14 @@ void merge_monitors(Monitor *monitors)
 
     if (monitors == NULL) {
         monitors = create_monitor("#Virtual", (uint32_t) -1);
-        monitors->size.width = g_screen->xcb_screen->width_in_pixels;
-        monitors->size.height = g_screen->xcb_screen->height_in_pixels;
+        monitors->size.width = screen->xcb_screen->width_in_pixels;
+        monitors->size.height = screen->xcb_screen->height_in_pixels;
     }
 
     /* copy frames from the old monitors to the new ones with same name */
     for (Monitor *monitor = monitors; monitor != NULL;
             monitor = monitor->next) {
-        named_monitor = get_monitor_by_name(g_screen->monitor,
+        named_monitor = get_monitor_by_name(screen->monitor,
                 monitor->name, strlen(monitor->name));
         if (named_monitor != NULL) {
             free(monitor->frame);
@@ -498,7 +504,7 @@ void merge_monitors(Monitor *monitors)
     }
 
     /* for the remaining monitors try to find any monitors to take the frames */
-    for (Monitor *monitor = g_screen->monitor; monitor != NULL;
+    for (Monitor *monitor = screen->monitor; monitor != NULL;
             monitor = next_monitor) {
         next_monitor = monitor->next;
         if (monitor->frame != NULL) {
@@ -516,8 +522,8 @@ void merge_monitors(Monitor *monitors)
 
             /* abandon the frame if there is no monitor that can take it */
             if (other == NULL) {
-                if (g_cur_frame == monitor->frame) {
-                    g_cur_frame = NULL;
+                if (focus_frame == monitor->frame) {
+                    focus_frame = NULL;
                 }
                 abandon_frame(monitor->frame);
             }
@@ -526,11 +532,11 @@ void merge_monitors(Monitor *monitors)
         free(monitor);
     }
 
-    g_screen->monitor = monitors;
+    screen->monitor = monitors;
 
     reconfigure_monitor_frame_sizes();
 
-    if (g_cur_frame == NULL) {
-        g_cur_frame = get_primary_monitor()->frame;
+    if (focus_frame == NULL) {
+        focus_frame = get_primary_monitor()->frame;
     }
 }

--- a/src/window_properties.c
+++ b/src/window_properties.c
@@ -45,9 +45,8 @@ static void update_window_size_hints(Window *window)
 {
     xcb_get_property_cookie_t size_hints_cookie;
 
-    size_hints_cookie = xcb_icccm_get_wm_size_hints(g_dpy, window->xcb_window,
-            XCB_ATOM_WM_NORMAL_HINTS);
-    if (!xcb_icccm_get_wm_size_hints_reply(g_dpy, size_hints_cookie,
+    size_hints_cookie = xcb_icccm_get_wm_normal_hints(connection, window->xcb_window);
+    if (!xcb_icccm_get_wm_size_hints_reply(connection, size_hints_cookie,
                 &window->properties.size_hints, NULL)) {
         window->properties.size_hints.flags = 0;
     }
@@ -58,8 +57,8 @@ static void update_window_hints(Window *window)
 {
     xcb_get_property_cookie_t hints_cookie;
 
-    hints_cookie = xcb_icccm_get_wm_hints(g_dpy, window->xcb_window);
-    if (!xcb_icccm_get_wm_hints_reply(g_dpy, hints_cookie,
+    hints_cookie = xcb_icccm_get_wm_hints(connection, window->xcb_window);
+    if (!xcb_icccm_get_wm_hints_reply(connection, hints_cookie,
                 &window->properties.hints, NULL)) {
         window->properties.hints.flags = 0;
     }
@@ -140,9 +139,9 @@ static void update_window_transient_for(Window *window)
 {
     xcb_get_property_cookie_t transient_for_cookie;
 
-    transient_for_cookie = xcb_icccm_get_wm_transient_for(g_dpy,
+    transient_for_cookie = xcb_icccm_get_wm_transient_for(connection,
             window->xcb_window);
-    if (!xcb_icccm_get_wm_transient_for_reply(g_dpy, transient_for_cookie,
+    if (!xcb_icccm_get_wm_transient_for_reply(connection, transient_for_cookie,
                 &window->properties.transient_for, NULL)) {
         window->properties.transient_for = 0;
     }
@@ -166,9 +165,9 @@ static void update_window_protocols(Window *window)
     xcb_get_property_cookie_t protocols_cookie;
     xcb_icccm_get_wm_protocols_reply_t protocols;
 
-    protocols_cookie = xcb_icccm_get_wm_protocols(g_dpy, window->xcb_window,
+    protocols_cookie = xcb_icccm_get_wm_protocols(connection, window->xcb_window,
             ewmh.WM_PROTOCOLS);
-    if (!xcb_icccm_get_wm_protocols_reply(g_dpy, protocols_cookie, &protocols,
+    if (!xcb_icccm_get_wm_protocols_reply(connection, protocols_cookie, &protocols,
                 NULL)) {
         window->properties.protocols = NULL;
         window->properties.number_of_protocols = 0;

--- a/src/window_state.c
+++ b/src/window_state.c
@@ -3,6 +3,7 @@
 #include "fensterchef.h"
 #include "frame.h"
 #include "log.h"
+#include "root_properties.h"
 #include "screen.h"
 #include "util.h"
 #include "window.h"
@@ -35,17 +36,32 @@ static void (*transitions[3][3])(Window *window) = {
     [WINDOW_MODE_FULLSCREEN][WINDOW_MODE_POPUP] = transition_fullscreen_popup,
 };
 
-/* Predicts what kind of mode the window should be in. */
+/* Predicts what kind of mode the window should be in.
+ * TODO: should this be adjustable in the user configuration?
+ */
 window_mode_t predict_window_mode(Window *window)
 {
     if (does_window_have_state(window, ewmh._NET_WM_STATE_FULLSCREEN)) {
         return WINDOW_MODE_FULLSCREEN;
     }
 
+    /* transient windows are popup windows */
     if (window->properties.transient_for != 0) {
         return WINDOW_MODE_POPUP;
     }
 
+    /* popup windows have an equal minimum and maximum size */
+    if ((window->properties.size_hints.flags &
+                (XCB_ICCCM_SIZE_HINT_P_MIN_SIZE | XCB_ICCCM_SIZE_HINT_P_MAX_SIZE)) ==
+                (XCB_ICCCM_SIZE_HINT_P_MIN_SIZE | XCB_ICCCM_SIZE_HINT_P_MAX_SIZE) &&
+            (window->properties.size_hints.min_width ==
+                window->properties.size_hints.max_width ||
+            window->properties.size_hints.min_height ==
+                window->properties.size_hints.max_height)) {
+        return WINDOW_MODE_POPUP;
+    }
+
+    /* popup windows do not have the normal window type */
     if (window->properties.number_of_types > 0) {
         if (window->properties.types[0] == ewmh._NET_WM_WINDOW_TYPE_NORMAL) {
             return WINDOW_MODE_TILING;
@@ -53,11 +69,12 @@ window_mode_t predict_window_mode(Window *window)
         return WINDOW_MODE_POPUP;
     }
 
-    /* cheat: popup windows have a maximum size */
+    /* popup windows have a maximum size */
     if ((window->properties.size_hints.flags & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE)) {
         return WINDOW_MODE_POPUP;
     }
 
+    /* fall back to tiling window */
     return WINDOW_MODE_TILING;
 }
 
@@ -112,44 +129,44 @@ static void configure_popup_size(Window *window)
     if ((window->properties.size_hints.flags & XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY)) {
         switch (window->properties.size_hints.win_gravity) {
         case XCB_GRAVITY_NORTH_WEST:
-            x = monitor->frame->width - width;
-            y = 0;
+            x = monitor->position.x;
+            y = monitor->position.y;
             break;
 
         case XCB_GRAVITY_NORTH:
-            y = 0;
+            y = monitor->position.y;
             break;
 
         case XCB_GRAVITY_NORTH_EAST:
-            x = 0;
-            y = 0;
+            x = monitor->position.x + monitor->size.width - width;
+            y = monitor->position.y;
             break;
         
         case XCB_GRAVITY_WEST:
-            x = monitor->frame->width - width;
+            x = monitor->position.x;
             break;
 
         case XCB_GRAVITY_CENTER:
-            x = (monitor->frame->width - width) / 2;
-            y = (monitor->frame->height - height) / 2;
+            x = monitor->position.x + (monitor->size.width - width) / 2;
+            y = monitor->position.y + (monitor->size.height - height) / 2;
             break;
 
         case XCB_GRAVITY_EAST:
-            x = 0;
+            x = monitor->position.x + monitor->size.width - width;
             break;
 
         case XCB_GRAVITY_SOUTH_WEST:
-            x = monitor->frame->width - width;
-            y = monitor->frame->height - height;
+            x = monitor->position.x;
+            y = monitor->position.y + monitor->size.height - height;
             break;
 
         case XCB_GRAVITY_SOUTH:
-            y = monitor->frame->height - height;
+            y = monitor->position.y + monitor->size.height - height;
             break;
 
         case XCB_GRAVITY_SOUTH_EAST:
-            x = 0;
-            y = monitor->frame->width - height;
+            x = monitor->position.x + monitor->size.width - width;
+            y = monitor->position.y + monitor->size.width - height;
             break;
         }
     }
@@ -178,13 +195,6 @@ static void configure_fullscreen_size(Window *window)
     }
 }
 
-/* Unmaps a window and sets it to hidden without any mode transitioning. */
-static void quick_hide(Window *window)
-{
-    xcb_unmap_window(g_dpy, window->xcb_window);
-    window->state.is_visible = false;
-}
-
 static void transition_tiling_popup(Window *window)
 {
     Window *next;
@@ -192,10 +202,7 @@ static void transition_tiling_popup(Window *window)
     next = get_next_hidden_window(window);
     if (next != NULL) {
         link_window_and_frame(next, window->frame);
-
-        next->state.is_visible = true;
-
-        xcb_map_window(g_dpy, next->xcb_window);
+        show_window_quickly(next);
     } else {
         window->frame->window = NULL;
         window->frame = NULL;
@@ -212,10 +219,7 @@ static void transition_tiling_fullscreen(Window *window)
     next = get_next_hidden_window(window);
     if (next != NULL) {
         link_window_and_frame(next, window->frame);
-
-        next->state.is_visible = true;
-
-        xcb_map_window(g_dpy, next->xcb_window);
+        show_window_quickly(next);
     } else {
         window->frame->window = NULL;
         window->frame = NULL;
@@ -229,14 +233,14 @@ static void transition_popup_tiling(Window *window)
 {
     Window *old_window;
 
-    old_window = g_cur_frame->window;
+    old_window = focus_frame->window;
 
-    link_window_and_frame(window, g_cur_frame);
+    link_window_and_frame(window, focus_frame);
 
     set_focus_window(window);
 
     if (old_window != NULL) {
-        quick_hide(old_window);
+        hide_window_quickly(old_window);
     }
 }
 
@@ -251,7 +255,8 @@ static void transition_fullscreen_popup(Window *window)
 }
 
 /* Changes the window state to given value and reconfigures the window only
- * if the mode changed. */
+ * if the mode changed.
+ */
 void set_window_mode(Window *window, window_mode_t mode, bool force_mode)
 {
     if (window->state.mode == mode ||
@@ -274,23 +279,41 @@ void set_window_mode(Window *window, window_mode_t mode, bool force_mode)
     window->state.previous_mode = window->state.mode;
     window->state.mode = mode;
 
-    synchronize_window_property(window,
-            WINDOW_EXTERNAL_PROPERTY_ALLOWED_ACTIONS);
+    synchronize_window_property(window, WINDOW_EXTERNAL_PROPERTY_ALLOWED_ACTIONS);
+}
+
+/* Show given window but do not assign an id and no size configuring. */
+void show_window_quickly(Window *window)
+{
+    if (window->state.is_visible) {
+        return;
+    }
+
+    LOG("quickly showing window with id: %" PRIu32 "\n", window->number);
+
+    window->state.is_visible = true;
+
+    xcb_map_window(connection, window->xcb_window);
+
+    if (window->state.mode == WINDOW_MODE_POPUP &&
+            !is_strut_empty(&window->properties.struts)) {
+        reconfigure_monitor_frame_sizes();
+        synchronize_root_property(ROOT_PROPERTY_WORK_AREA);
+    }
 }
 
 /* Show the window by mapping it to the X server. */
 void show_window(Window *window)
 {
     Window *last, *previous;
-    Window *old_window;
 
     if (window->state.is_visible) {
         return;
     }
 
     /* assign the first id to the window if it is first mapped */
-    if (!window->state.is_mappable) {
-        for (last = g_first_window; last->next != NULL; last = last->next) {
+    if (!window->state.was_ever_mapped) {
+        for (last = first_window; last->next != NULL; last = last->next) {
             if (last->number + 1 < last->next->number) {
                 break;
             }
@@ -301,39 +324,38 @@ void show_window(Window *window)
                 window->number, window->xcb_window);
 
         if (last != window) {
-            if (window != g_first_window) {
+            if (window != first_window) {
                 previous = get_previous_window(window);
                 previous->next = window->next;
             } else {
-                g_first_window = window->next;
+                first_window = window->next;
             }
             window->next = last->next;
             last->next = window;
         }
 
-        window->state.is_mappable = true;
+        window->state.was_ever_mapped = true;
     }
-
-    window->state.is_visible = true;
 
     LOG("showing window with id: %" PRIu32 "\n", window->number);
 
-    xcb_map_window(g_dpy, window->xcb_window);
+    window->state.is_visible = true;
 
+    previous = NULL;
     switch (window->state.mode) {
     /* the window has to become part of the tiling layout */
     case WINDOW_MODE_TILING:
-        old_window = g_cur_frame->window;
-        link_window_and_frame(window, g_cur_frame);
-        set_focus_window(window);
-        if (old_window != NULL) {
-            quick_hide(old_window);
-        }
+        previous = focus_frame->window;
+        link_window_and_frame(window, focus_frame);
         break;
 
     /* the window has to show as popup window */
     case WINDOW_MODE_POPUP:
         configure_popup_size(window);
+        if (!is_strut_empty(&window->properties.struts)) {
+            reconfigure_monitor_frame_sizes();
+            synchronize_root_property(ROOT_PROPERTY_WORK_AREA);
+        }
         break;
 
     /* the window has to show as fullscreen window */
@@ -344,6 +366,50 @@ void show_window(Window *window)
     /* not a real window mode */
     case WINDOW_MODE_MAX:
         break;
+    }
+
+    /* map the window before unmapping to avoid flicker */
+    xcb_map_window(connection, window->xcb_window);
+
+    if (previous != NULL) {
+        hide_window_quickly(previous);
+    }
+}
+
+/* Hide a window without focusing another window. */
+void hide_window_quickly(Window *window)
+{
+    if (!window->state.is_visible) {
+        return;
+    }
+
+    LOG("quickly hiding window with id: %" PRIu32 "\n", window->number);
+
+    window->state.is_visible = false;
+
+    if (focus_window == window) {
+        focus_window = window->previous_focus;
+    }
+
+    unlink_window_from_focus_list(window);
+
+    xcb_unmap_window(connection, window->xcb_window);
+
+    if (window->state.mode == WINDOW_MODE_POPUP &&
+            !is_strut_empty(&window->properties.struts)) {
+        reconfigure_monitor_frame_sizes();
+        synchronize_root_property(ROOT_PROPERTY_WORK_AREA);
+    }
+}
+
+/* Focus the window that was in focus before the currently focused one. */
+static void focus_previous_window(void)
+{
+    if (focus_window->previous_focus != focus_window) {
+        set_focus_window_with_frame(focus_window->previous_focus);
+    } else {
+        focus_window = NULL;
+        synchronize_root_property(ROOT_PROPERTY_ACTIVE_WINDOW);
     }
 }
 
@@ -356,6 +422,8 @@ void hide_window(Window *window)
         return;
     }
 
+    LOG("hiding window with id: %" PRIu32 "\n", window->number);
+
     window->state.is_visible = false;
 
     switch (window->state.mode) {
@@ -364,25 +432,25 @@ void hide_window(Window *window)
         next = get_next_hidden_window(window);
         if (next != NULL) {
             link_window_and_frame(next, window->frame);
-
-            next->state.is_visible = true;
-
-            xcb_map_window(g_dpy, next->xcb_window);
-
-            set_focus_window(window);
+            show_window_quickly(next);
+            if (window == focus_window) {
+                set_focus_window(next);
+            }
         } else {
-            if (window == get_focus_window()) {
-                give_someone_else_focus(window);
+            if (window == focus_window) {
+                focus_previous_window();
             }
             window->frame->window = NULL;
-            window->frame = NULL;
         }
+        window->frame = NULL;
         break;
 
-    /* need to do nothing here, just unmap and focus a different window */
+    /* need to do nothing here, just focus a different window */
     case WINDOW_MODE_POPUP:
     case WINDOW_MODE_FULLSCREEN:
-        give_someone_else_focus(window);
+        if (window == focus_window) {
+            focus_previous_window();
+        }
         break;
 
     /* not a real window mode */
@@ -390,5 +458,13 @@ void hide_window(Window *window)
         break;
     }
 
-    xcb_unmap_window(g_dpy, window->xcb_window);
+    unlink_window_from_focus_list(window);
+
+    xcb_unmap_window(connection, window->xcb_window);
+
+    if (window->state.mode == WINDOW_MODE_POPUP &&
+            !is_strut_empty(&window->properties.struts)) {
+        reconfigure_monitor_frame_sizes();
+        synchronize_root_property(ROOT_PROPERTY_WORK_AREA);
+    }
 }


### PR DESCRIPTION
Nun gibt es die Fokus Chain, die alle sichtbaren Fenster, die Fokus
erhalten haben beinhaltet.

Das FocusIn Event wird nun gehandlet. Wenn ein Fenster extern Fokus in
Anspruch nimmt, wird es nun intern auch gefocused.

Es werden Variablennamen verbessert:
g_dpy -> connection
keysyms -> key_symbols
g_running -> is_fensterchef_running
g_values -> general_values
Window.state.is_mappable -> Window.state.was_ever_mapped

Es gibt kleine Bug Fixes, die mit der Verkettung von Window und Frame zu
tun hatten in tiling.c.