### PR TITLE
Window resize handling

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -53,6 +53,8 @@ typedef enum {
     ACTION_SHOW_MESSAGE,
     /* show a notification with a message extracted from a shell program */
     ACTION_SHOW_MESSAGE_RUN,
+    /* resize the edges of the current window */
+    ACTION_RESIZE_BY,
     /* quits fensterchef */
     ACTION_QUIT,
 

--- a/include/bits/configuration_parser_data_type.h
+++ b/include/bits/configuration_parser_data_type.h
@@ -11,9 +11,9 @@
 
 /* data types the parser understands
  *
- * NOTE: After editing a data type, also edit the data_type_parsers[] array in
- * configuration_parser.c and implement its parser function. It can then be used
- * in parse_line().
+ * NOTE: After editing a data type, also edit the data_types[] array in
+ * configuration_parser.c and implement its parser function. It will then be
+ * automatically used in parse_line().
  */
 typedef enum parser_data_type {
     /* no data type at all */
@@ -24,6 +24,8 @@ typedef enum parser_data_type {
     PARSER_DATA_TYPE_STRING,
     /* an integer in simple decimal notation */
     PARSER_DATA_TYPE_INTEGER,
+    /* a set of 4 integers */
+    PARSER_DATA_TYPE_QUAD,
     /* color in the format (X: hexadecimal digit): #XXXXXX */
     PARSER_DATA_TYPE_COLOR,
     /* key modifiers, e.g.: Control+Shift */
@@ -39,7 +41,9 @@ union parser_data_value {
     /* any utf8 text without leading or trailing space */
     uint8_t *string;
     /* an integer in simple decimal notation */
-    uint32_t integer;
+    int32_t integer;
+    /* a set of 4 integers */
+    int32_t quad[4];
     /* color in the format (X: hexadecimal digit): #XXXXXX */
     uint32_t color;
     /* key modifiers, e.g.: Control+Shift */

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -12,6 +12,9 @@
 /* maximum length of an identifier */
 #define PARSER_IDENTIFIER_LIMIT 64
 
+/* maximum value for an integer */
+#define PARSER_INTEGER_LIMIT 1000000
+
 /* parser error codes
  * 
  * NOTE: After editing an error code, also edit the parser_error_strings[] in
@@ -107,8 +110,6 @@ typedef struct parser {
 const char *parser_string_error(parser_error_t error);
 
 /* Read the next line from the file.
- *
- * Skips any empty lines.
  *
  * @return if there is any line left.
  */

--- a/include/event.h
+++ b/include/event.h
@@ -1,13 +1,15 @@
 #ifndef EVENT_H
 #define EVENT_H
 
-#include <xcb/xcb.h>
+#include "bits/window_typedef.h"
+
+#include "x11_management.h"
 
 /* this is the first index of a randr event */
 extern uint8_t randr_event_base;
 
-/* Creates signal handlers and prepares for calling `next_cycle()`. */
-int prepare_cycles(void);
+/* Create a signal handler for `SIGALRM`. */
+int initialize_signal_handlers(void);
 
 /* called before processing any events or signals */
 #define CYCLE_PREPARE 0
@@ -24,6 +26,11 @@ int prepare_cycles(void);
  *      `(*callback)(CYCLE_EVENT, event);`.
  */
 int next_cycle(int (*callback)(int cycle_when, xcb_generic_event_t *event));
+
+/* Start resizing a window using the mouse. */
+void initiate_window_move_resize(Window *window,
+        wm_move_resize_direction_t direction,
+        int32_t start_x, int32_t start_y);
 
 /* Handle the given X event. */
 void handle_event(xcb_generic_event_t *event);

--- a/include/frame.h
+++ b/include/frame.h
@@ -8,6 +8,10 @@
 #include "bits/frame_typedef.h"
 #include "bits/window_typedef.h"
 
+/* the minimum width or height of a frame */
+#define FRAME_MINIMUM_SIZE 12
+
+/* an edge of the frame */
 typedef enum {
     FRAME_EDGE_LEFT,
     FRAME_EDGE_TOP,
@@ -15,6 +19,7 @@ typedef enum {
     FRAME_EDGE_BOTTOM,
 } frame_edge_t;
 
+/* a direction to split a frame in */
 typedef enum {
     /* the frame was split horizontally (children are left and right) */
     FRAME_SPLIT_HORIZONTALLY,

--- a/include/frame.h
+++ b/include/frame.h
@@ -8,6 +8,20 @@
 #include "bits/frame_typedef.h"
 #include "bits/window_typedef.h"
 
+typedef enum {
+    FRAME_EDGE_LEFT,
+    FRAME_EDGE_TOP,
+    FRAME_EDGE_RIGHT,
+    FRAME_EDGE_BOTTOM,
+} frame_edge_t;
+
+typedef enum {
+    /* the frame was split horizontally (children are left and right) */
+    FRAME_SPLIT_HORIZONTALLY,
+    /* the frame was split vertically (children are up and down) */
+    FRAME_SPLIT_VERTICALLY,
+} frame_split_direction_t;
+
 /* Frames are used to partition a monitor into multiple rectangular regions.
  *
  * When a frame has one child, it must have a second one, so either BOTH left
@@ -24,9 +38,12 @@ struct frame {
     uint32_t width;
     uint32_t height;
 
+    /* the direction the frame was split in */
+    frame_split_direction_t split_direction;
+
     /* parent of the frame */
     Frame *parent;
-    /* left and right child of the frame */
+    /* left child and right child of the frame */
     Frame *left;
     Frame *right;
 };

--- a/include/log.h
+++ b/include/log.h
@@ -22,10 +22,6 @@
     fprintf(stderr, __VA_ARGS__); \
 } while (0)
 
-#define LOG_ADDITIONAL(...) do { \
-    fprintf(stderr, __VA_ARGS__); \
-} while (0)
-
 /* Log a formatted message with error indication. */
 #define LOG_ERROR(xcb_error, ...) do { \
     char time_buffer_[64]; \

--- a/include/render.h
+++ b/include/render.h
@@ -28,7 +28,7 @@ enum {
     STOCK_MAX,
 };
 
-/* graphical objects with the id referring to the xcb id */
+/* graphical objects with the id referring to the X id */
 extern uint32_t stock_objects[STOCK_MAX];
 
 /* Initialize the graphical stock objects that can be used for rendering. */
@@ -61,9 +61,7 @@ static inline void convert_color_to_xcb_color(xcb_render_color_t *xcb_color,
 
 /* This sets the globally used font for rendering.
  *
- * @name can be NULL to set the default font.
- *
- * @return 0 on success or 1 when the font was not found.
+ * @return OK on success or ERROR when the font was not found.
  */
 int set_font(const utf8_t *query);
 

--- a/include/tiling.h
+++ b/include/tiling.h
@@ -3,11 +3,11 @@
 
 #include "frame.h"
 
-/* Split a frame horizontally or vertically. 
- *
- * @is_split_vert true for a vertical split and false for a horizontal split.
- */
-void split_frame(Frame *split_from, bool is_split_vert);
+/* Increases the @edge of @frame by @amount. */
+int32_t bump_frame_edge(Frame *frame, frame_edge_t edge, int32_t amount);
+
+/* Split a frame horizontally or vertically. */
+void split_frame(Frame *split_from, frame_split_direction_t direction);
 
 /* Remove a frame from the screen and hide the inner windows.
  *

--- a/include/window.h
+++ b/include/window.h
@@ -12,6 +12,15 @@
 
 #include "x11_management.h"
 
+/* the maximum size of the window */
+#define WINDOW_MAXIMUM_SIZE 1000000
+
+/* the minimum length of the window that needs to stay visible */
+#define WINDOW_MINIMUM_VISIBLE_SIZE 8
+
+/* the minimum width or height a window can have */
+#define WINDOW_MINIMUM_SIZE 4
+
 /* the number the first window gets assigned */
 #define FIRST_WINDOW_NUMBER 1
 

--- a/include/window.h
+++ b/include/window.h
@@ -3,12 +3,12 @@
 
 #include <stdint.h>
 
-#include "utility.h"
-
-#include "window_state.h"
-
 #include "bits/window_typedef.h"
 #include "bits/frame_typedef.h"
+
+#include "monitor.h"
+#include "utility.h"
+#include "window_state.h"
 
 #include "x11_management.h"
 
@@ -75,6 +75,10 @@ void close_window(Window *window);
  * This does NOT destroy the underlying xcb window.
  */
 void destroy_window(Window *window);
+
+/* Adjust given @x and @y such that it follows the @window_gravity. */
+void adjust_for_window_gravity(Monitor *monitor, int32_t *x, int32_t *y,
+        uint32_t width, uint32_t height, uint32_t window_gravity);
 
 /* Set the position and size of a window. */
 void set_window_size(Window *window, int32_t x, int32_t y, uint32_t width,

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -20,9 +20,6 @@ typedef enum window_mode {
     WINDOW_MODE_MAX,
 } window_mode_t;
 
-#define DOES_WINDOW_MODE_HAVE_BORDER(mode) \
-    ((mode) == WINDOW_MODE_TILING || (mode) == WINDOW_MODE_POPUP)
-
 /* The state of the window signals our window manager what kind of window it is
  * and how the window should behave.
  */
@@ -37,9 +34,9 @@ typedef struct window_state {
     bool was_close_requested;
     /* when the user requested to close the window */
     time_t user_request_close_time;
-    /* the current window state */
+    /* the current window mode */
     window_mode_t mode;
-    /* the previous window state */
+    /* the previous window mode */
     window_mode_t previous_mode;
 } WindowState;
 
@@ -47,6 +44,9 @@ typedef struct window_state {
  * properties.
  */
 window_mode_t predict_window_mode(Window *window);
+
+/* Check if @window has a visible border currently. */
+bool has_window_border(Window *window);
 
 /* Change the mode to given value and reconfigures the window if it is visible.
  *

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -107,10 +107,44 @@ void merge_with_default_key_bindings(struct configuration *configuration)
         { 0, XK_l, { .code = ACTION_MOVE_RIGHT } },
         { 0, XK_j, { .code = ACTION_MOVE_DOWN } },
 
+        { 0, XK_Left, { ACTION_RESIZE_BY, {
+                .quad = { 20, 0, 0, 0 } } } },
+        { 0, XK_Up, { ACTION_RESIZE_BY, {
+                .quad = { 0, 20, 0, 0 } } } },
+        { 0, XK_Right, { ACTION_RESIZE_BY, {
+                .quad = { -20, 0, 0, 0 } } } },
+        { 0, XK_Down, { ACTION_RESIZE_BY, {
+                .quad = { 0, -20, 0, 0 } } } },
+
+        { XCB_MOD_MASK_SHIFT, XK_Left, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, -20, 0 } } } },
+        { XCB_MOD_MASK_SHIFT, XK_Up, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, 0, -20 } } } },
+        { XCB_MOD_MASK_SHIFT, XK_Right, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, 20, 0 } } } },
+        { XCB_MOD_MASK_SHIFT, XK_Down, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, 0, 20 } } } },
+
+        { XCB_MOD_MASK_CONTROL, XK_Left, { ACTION_RESIZE_BY, {
+                .quad = { 20, 0, -20, 0 } } } },
+        { XCB_MOD_MASK_CONTROL, XK_Up, { ACTION_RESIZE_BY, {
+                .quad = { 0, 20, 0, -20 } } } },
+        { XCB_MOD_MASK_CONTROL, XK_Right, { ACTION_RESIZE_BY, {
+                .quad = { -20, 0, 20, 0 } } } },
+        { XCB_MOD_MASK_CONTROL, XK_Down, { ACTION_RESIZE_BY, {
+                .quad = { 0, -20, 0, 20 } } } },
+
+        { XCB_MOD_MASK_CONTROL, XK_plus, { ACTION_RESIZE_BY, {
+                .quad = { 10, 10, 10, 10 } } } },
+        { XCB_MOD_MASK_CONTROL, XK_minus, { ACTION_RESIZE_BY, {
+                .quad = { -10, -10, -10, -10 } } } },
+        { XCB_MOD_MASK_CONTROL, XK_equal, { ACTION_RESIZE_BY, {
+                .quad = { 10, 10, 10, 10 } } } },
+
         { 0, XK_w, { .code = ACTION_SHOW_WINDOW_LIST } },
 
         { 0, XK_Return, { ACTION_RUN, {
-            .string = (uint8_t*) "/usr/bin/xterm" } } },
+                .string = (uint8_t*) "/usr/bin/xterm" } } },
 
         { XCB_MOD_MASK_SHIFT, XK_e, { .code = ACTION_QUIT } }
     };

--- a/src/frame.c
+++ b/src/frame.c
@@ -92,35 +92,32 @@ void resize_frame(Frame *frame, int32_t x, int32_t y,
 /* Resize the inner window to fit within the frame. */
 void reload_frame(Frame *frame)
 {
-    Monitor *monitor;
+    Frame *root;
     uint32_t left, top, right, bottom;
 
     if (frame->window == NULL) {
         return;
     }
-    monitor = get_monitor_from_rectangle(frame->x, frame->y,
-            frame->width, frame->height);
-    if (monitor->position.x == frame->x) {
+    root = get_root_frame(frame);
+    if (root->x == frame->x) {
         left = configuration.gaps.outer;
     } else {
         left = configuration.gaps.inner;
     }
 
-    if (monitor->position.y == frame->y) {
+    if (root->y == frame->y) {
         top = configuration.gaps.outer;
     } else {
         top = configuration.gaps.inner;
     }
 
-    if (monitor->position.x + monitor->size.width ==
-            frame->x + frame->width) {
+    if (root->x + root->width == frame->x + frame->width) {
         right = configuration.gaps.outer;
     } else {
         right = 0;
     }
 
-    if (monitor->position.y + monitor->size.height ==
-            frame->y + frame->height) {
+    if (root->y + root->height == frame->y + frame->height) {
         bottom = configuration.gaps.outer;
     } else {
         bottom = 0;

--- a/src/frame.c
+++ b/src/frame.c
@@ -45,14 +45,16 @@ Frame *get_frame_at_position(int32_t x, int32_t y)
     return NULL;
 }
 
-/* Set the size of a frame, this also resize the inner frames and windows.
- *
- * TODO: keep ratio when resizing?
- */
+/* Set the size of a frame, this also resizes the inner frames and windows. */
 void resize_frame(Frame *frame, int32_t x, int32_t y,
         uint32_t width, uint32_t height)
 {
     Frame *left, *right;
+    uint32_t old_width, old_height;
+    uint32_t left_size;
+
+    old_width = frame->width;
+    old_height = frame->height;
 
     frame->x = x;
     frame->y = y;
@@ -68,19 +70,26 @@ void resize_frame(Frame *frame, int32_t x, int32_t y,
         return;
     }
 
-    /* check if the split is horizontal or vertical and place the children at
-     * half the area
-     */
-    if (left->x != right->x) {
-        resize_frame(left, x, y, width / 2, height);
-        resize_frame(right, x + left->width, y, width - left->width, height);
-    } else {
-        resize_frame(left, x, y, width, height / 2);
-        resize_frame(right, x, y + left->height, width, height - left->height);
+    switch (frame->split_direction) {
+    /* left to right split */
+    case FRAME_SPLIT_HORIZONTALLY:
+        left_size = old_width == 0 ? width / 2 :
+            width * left->width / old_width;
+        resize_frame(left, x, y, left_size, height);
+        resize_frame(right, x + left->width, y, width - left_size, height);
+        break;
+
+    /* top to bottom split */
+    case FRAME_SPLIT_VERTICALLY:
+        left_size = old_height == 0 ? height / 2 :
+            height * left->height / old_height;
+        resize_frame(left, x, y, width, left_size);
+        resize_frame(right, x, y + left->height, width, height - left_size);
+        break;
     }
 }
 
-/* Resizes the inner window to fit within the frame. */
+/* Resize the inner window to fit within the frame. */
 void reload_frame(Frame *frame)
 {
     Monitor *monitor;
@@ -116,11 +125,14 @@ void reload_frame(Frame *frame)
     } else {
         bottom = 0;
     }
+
+    right += left + configuration.border.size * 2;
+    bottom += top + configuration.border.size * 2;
     set_window_size(frame->window,
             frame->x + left,
             frame->y + top,
-            frame->width - left - right - configuration.border.size * 2,
-            frame->height - top - bottom - configuration.border.size * 2);
+            frame->width < right ? 0 : frame->width - right,
+            frame->height < bottom ? 0 : frame->height - bottom);
 }
 
 /* Set the frame in focus, this also focuses the inner window if possible. */

--- a/src/log.c
+++ b/src/log.c
@@ -2,6 +2,9 @@
 
 #include <inttypes.h>
 
+#include <xcb/randr.h>
+
+#include "event.h"
 #include "log.h"
 #include "utility.h"
 #include "x11_management.h"
@@ -50,229 +53,244 @@ static const char *generic_event_strings[] = {
 /* Log an event to the log file. */
 void log_event(xcb_generic_event_t *event)
 {
-    uint8_t                         event_type;
-    xcb_generic_error_t             *error;
-    xcb_key_press_event_t           *kp;
-    xcb_button_press_event_t        *bp;
-    xcb_motion_notify_event_t       *mn;
-    xcb_enter_notify_event_t        *en;
-    xcb_focus_in_event_t            *fi;
-    xcb_keymap_notify_event_t       *kn;
-    xcb_expose_event_t              *e;
-    xcb_graphics_exposure_event_t   *ge;
-    xcb_no_exposure_event_t         *ne;
-    xcb_visibility_notify_event_t   *vn;
-    xcb_create_notify_event_t       *crn;
-    xcb_destroy_notify_event_t      *dn;
-    xcb_unmap_notify_event_t        *un;
-    xcb_map_notify_event_t          *man;
-    xcb_map_request_event_t         *mr;
-    xcb_reparent_notify_event_t     *rn;
-    xcb_configure_notify_event_t    *cn;
-    xcb_configure_request_event_t   *cr;
-    xcb_gravity_notify_event_t      *gn;
-    xcb_resize_request_event_t      *rr;
-    xcb_circulate_notify_event_t    *cin;
-    xcb_circulate_request_event_t   *cir;
-    xcb_property_notify_event_t     *pn;
-    xcb_selection_clear_event_t     *sc;
-    xcb_selection_request_event_t   *sr;
-    xcb_selection_notify_event_t    *sn;
-    xcb_colormap_notify_event_t     *con;
-    xcb_client_message_event_t      *cln;
-    xcb_mapping_notify_event_t      *min;
-    xcb_ge_generic_event_t          *gen;
+    uint8_t                                 event_type;
+    xcb_randr_screen_change_notify_event_t  *rscn;
+    xcb_generic_error_t                     *error;
+    xcb_key_press_event_t                   *kp;
+    xcb_button_press_event_t                *bp;
+    xcb_motion_notify_event_t               *mn;
+    xcb_enter_notify_event_t                *en;
+    xcb_focus_in_event_t                    *fi;
+    xcb_keymap_notify_event_t               *kn;
+    xcb_expose_event_t                      *e;
+    xcb_graphics_exposure_event_t           *ge;
+    xcb_no_exposure_event_t                 *ne;
+    xcb_visibility_notify_event_t           *vn;
+    xcb_create_notify_event_t               *crn;
+    xcb_destroy_notify_event_t              *dn;
+    xcb_unmap_notify_event_t                *un;
+    xcb_map_notify_event_t                  *man;
+    xcb_map_request_event_t                 *mr;
+    xcb_reparent_notify_event_t             *rn;
+    xcb_configure_notify_event_t            *cn;
+    xcb_configure_request_event_t           *cr;
+    xcb_gravity_notify_event_t              *gn;
+    xcb_resize_request_event_t              *rr;
+    xcb_circulate_notify_event_t            *cin;
+    xcb_circulate_request_event_t           *cir;
+    xcb_property_notify_event_t             *pn;
+    xcb_selection_clear_event_t             *sc;
+    xcb_selection_request_event_t           *sr;
+    xcb_selection_notify_event_t            *sn;
+    xcb_colormap_notify_event_t             *con;
+    xcb_client_message_event_t              *cln;
+    xcb_mapping_notify_event_t              *min;
+    xcb_ge_generic_event_t                  *gen;
 
     event_type = (event->response_type & ~0x80);
-    fputs(xcb_event_get_label(event_type), stderr);
+    if (event_type == randr_event_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
+        fputs("RandrScreenChangeNotify", stderr);
+    } else if (event_type == randr_event_base + XCB_RANDR_NOTIFY) {
+        fputs("RandrNotify", stderr);
+    } else if (xcb_event_get_label(event_type) != NULL) {
+        fputs(xcb_event_get_label(event_type), stderr);
+    } else {
+        fprintf(stderr, "EVENT[%d]", event_type);
+    }
     if (event_type == XCB_GE_GENERIC) {
         gen = (xcb_ge_generic_event_t*) event;
         if (gen->extension >= SIZE(generic_event_strings)) {
-            fprintf(stderr, "UNKNOWN_EVENT[%" PRIu8 "]", event_type);
+            fprintf(stderr, "EVENT[%" PRIu8 "]", event_type);
         } else {
             fprintf(stderr, "%s", generic_event_strings[gen->extension]);
         }
     }
 
-    fputc('(', stderr);
+    fprintf(stderr, "(detail=%" PRIu8 ", sequence=%" PRIu16,
+            event->pad0, event->sequence);
+    if (event_type == randr_event_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
+        rscn = (xcb_randr_screen_change_notify_event_t*) event;
+        fprintf(stderr, ", size=%" PRIu16 "x%" PRIu16 ", millimeter size=%" PRIu16 "x%" PRIu16,
+                rscn->width, rscn->height, rscn->mwidth, rscn->mheight);
+    }
     switch (event_type) {
     case 0:
         error = (xcb_generic_error_t*) event;
-        fprintf(stderr, "label=%s, code=%" PRIu8 ", sequence=%" PRIu16 ", major=%" PRIu8 ", minor=%" PRIu16,
+        fprintf(stderr, ", label=%s, code=%" PRIu8 ", major=%" PRIu8 ", minor=%" PRIu16,
                 xcb_event_get_error_label(error->error_code),
-                error->error_code, error->sequence, error->major_code,
+                error->error_code, error->major_code,
                 error->minor_code);
         break;
 
     case XCB_KEY_PRESS:
     case XCB_KEY_RELEASE:
         kp = (xcb_key_press_event_t*) event;
-        fprintf(stderr, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", mod=",
-                kp->time, kp->root, kp->event, kp->child, kp->detail);
+        fprintf(stderr, ", time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", mod=",
+                kp->time, kp->root, kp->event, kp->child);
         log_modifiers(kp->state);
         break;
 
     case XCB_BUTTON_PRESS:
     case XCB_BUTTON_RELEASE:
         bp = (xcb_button_press_event_t*) event;
-        fprintf(stderr, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", mod=",
-                bp->time, bp->root, bp->event, bp->child, bp->detail);
+        fprintf(stderr, ", time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", mod=",
+                bp->time, bp->root, bp->event, bp->child);
         log_modifiers(bp->state);
         break;
 
     case XCB_MOTION_NOTIFY:
         mn = (xcb_motion_notify_event_t*) event;
-        fprintf(stderr, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", detail=%" PRIu8 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16 ", mod=",
-                mn->time, mn->root, mn->event, mn->child, mn->detail, mn->root_x, mn->root_y, mn->event_x, mn->event_y);
+        fprintf(stderr, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16 ", mod=",
+                mn->time, mn->root, mn->event, mn->child, mn->root_x, mn->root_y, mn->event_x, mn->event_y);
         log_modifiers(mn->state);
         break;
 
     case XCB_ENTER_NOTIFY:
     case XCB_LEAVE_NOTIFY:
         en = (xcb_enter_notify_event_t*) event;
-        fprintf(stderr, "time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16,
+        fprintf(stderr, ", time=%" PRIu32 ", root=%" PRIu32 ", event=%" PRIu32 ", child=%" PRIu32 ", root_x=%" PRId16 ", root_y=%" PRId16 ", event_x=%" PRId16 ", event_y=%" PRId16,
                 en->time, en->root, en->event, en->child, en->root_x, en->root_y, en->event_x, en->event_y);
         break;
 
     case XCB_FOCUS_IN:
     case XCB_FOCUS_OUT:
         fi = (xcb_focus_in_event_t*) event;
-        fprintf(stderr, "mode=%" PRIu8 ", detail=%" PRIu8 ", event=%" PRIu32, fi->mode, fi->detail, fi->event);
+        fprintf(stderr, ", mode=%" PRIu8 ", event=%" PRIu32, fi->mode, fi->event);
         break;
 
     case XCB_KEYMAP_NOTIFY:
         kn = (xcb_keymap_notify_event_t*) event;
         (void) kn;
-        fprintf(stderr, "keys=..."); // Keymap is a large array; implement if needed
+        fprintf(stderr, ", keys=..."); // Keymap is a large array; implement if needed
         break;
 
     case XCB_EXPOSE:
         e = (xcb_expose_event_t*) event;
-        fprintf(stderr, "x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16,
+        fprintf(stderr, ", x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16,
                 e->x, e->y, e->width, e->height, e->count);
         break;
 
     case XCB_GRAPHICS_EXPOSURE:
         ge = (xcb_graphics_exposure_event_t*) event;
-        fprintf(stderr, "x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
+        fprintf(stderr, ", x=%" PRIu16 ", y=%" PRIu16 ", width=%" PRIu16 ", height=%" PRIu16 ", count=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
                 ge->x, ge->y, ge->width, ge->height, ge->count, ge->minor_opcode, ge->major_opcode);
         break;
 
     case XCB_NO_EXPOSURE:
         ne = (xcb_no_exposure_event_t*) event;
-        fprintf(stderr, "sequence=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
+        fprintf(stderr, ", sequence=%" PRIu16 ", minor_opcode=%" PRIu8 ", major_opcode=%" PRIu8,
                 ne->sequence, ne->minor_opcode, ne->major_opcode);
         break;
 
     case XCB_VISIBILITY_NOTIFY:
         vn = (xcb_visibility_notify_event_t*) event;
-        fprintf(stderr, "state=%" PRIu8, vn->state);
+        fprintf(stderr, ", state=%" PRIu8, vn->state);
         break;
 
     case XCB_CREATE_NOTIFY:
         crn = (xcb_create_notify_event_t*) event;
-        fprintf(stderr, "parent=%" PRIu32 ", window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(stderr, ", parent=%" PRIu32 ", window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
                 crn->parent, crn->window, crn->x, crn->y, crn->width, crn->height);
         break;
 
     case XCB_DESTROY_NOTIFY:
         dn = (xcb_destroy_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32, dn->window);
+        fprintf(stderr, ", window=%" PRIu32, dn->window);
         break;
 
     case XCB_UNMAP_NOTIFY:
         un = (xcb_unmap_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", from_configure=%" PRIu8,
+        fprintf(stderr, ", window=%" PRIu32 ", from_configure=%" PRIu8,
                 un->window, un->from_configure);
         break;
 
     case XCB_MAP_NOTIFY:
         man = (xcb_map_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", override_redirect=%" PRIu8,
+        fprintf(stderr, ", window=%" PRIu32 ", override_redirect=%" PRIu8,
                 man->window, man->override_redirect);
         break;
 
     case XCB_MAP_REQUEST:
         mr = (xcb_map_request_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", parent=%" PRIu32,
+        fprintf(stderr, ", window=%" PRIu32 ", parent=%" PRIu32,
                 mr->window, mr->parent);
         break;
 
     case XCB_REPARENT_NOTIFY:
         rn = (xcb_reparent_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", parent=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
+        fprintf(stderr, ", window=%" PRIu32 ", parent=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
                 rn->window, rn->parent, rn->x, rn->y);
         break;
 
     case XCB_CONFIGURE_NOTIFY:
         cn = (xcb_configure_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(stderr, ", window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
                 cn->window, cn->x, cn->y, cn->width, cn->height);
         break;
 
     case XCB_CONFIGURE_REQUEST:
         cr = (xcb_configure_request_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(stderr, ", window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16 ", width=%" PRIu16 ", height=%" PRIu16,
                 cr->window, cr->x, cr->y, cr->width, cr->height);
         break;
 
     case XCB_GRAVITY_NOTIFY:
         gn = (xcb_gravity_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
+        fprintf(stderr, ", window=%" PRIu32 ", x=%" PRIi16 ", y=%" PRIi16,
                 gn->window, gn->x, gn->y);
         break;
 
     case XCB_RESIZE_REQUEST:
         rr = (xcb_resize_request_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", width=%" PRIu16 ", height=%" PRIu16,
+        fprintf(stderr, ", window=%" PRIu32 ", width=%" PRIu16 ", height=%" PRIu16,
                 rr->window, rr->width, rr->height);
         break;
 
     case XCB_CIRCULATE_NOTIFY:
         cin = (xcb_circulate_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", place=%" PRIu8,
+        fprintf(stderr, ", window=%" PRIu32 ", place=%" PRIu8,
                 cin->window, cin->place);
         break;
 
     case XCB_CIRCULATE_REQUEST:
         cir = (xcb_circulate_request_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", place=%" PRIu8,
+        fprintf(stderr, ", window=%" PRIu32 ", place=%" PRIu8,
                 cir->window, cir->place);
         break;
 
     case XCB_PROPERTY_NOTIFY:
         pn = (xcb_property_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", atom=%" PRIu32 ", time=%" PRIu32 ", state=%" PRIu8,
+        fprintf(stderr, ", window=%" PRIu32 ", atom=%" PRIu32 ", time=%" PRIu32 ", state=%" PRIu8,
                 pn->window, pn->atom, pn->time, pn->state);
         break;
 
     case XCB_SELECTION_CLEAR:
         sc = (xcb_selection_clear_event_t*) event;
-        fprintf(stderr, "owner=%" PRIu32 ", selection=%" PRIu32 ", time=%" PRIu32,
+        fprintf(stderr, ", owner=%" PRIu32 ", selection=%" PRIu32 ", time=%" PRIu32,
                 sc->owner, sc->selection, sc->time);
         break;
 
     case XCB_SELECTION_REQUEST:
         sr = (xcb_selection_request_event_t*) event;
-        fprintf(stderr, "owner=%" PRIu32 ", requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32,
+        fprintf(stderr, ", owner=%" PRIu32 ", requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32,
                 sr->owner, sr->requestor, sr->selection, sr->target);
         break;
 
     case XCB_SELECTION_NOTIFY:
         sn = (xcb_selection_notify_event_t*) event;
-        fprintf(stderr, "requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32 ", property=%" PRIu32 ", time=%" PRIu32,
+        fprintf(stderr, ", requestor=%" PRIu32 ", selection=%" PRIu32 ", target=%" PRIu32 ", property=%" PRIu32 ", time=%" PRIu32,
                 sn->requestor, sn->selection, sn->target, sn->property, sn->time);
         break;
 
     case XCB_COLORMAP_NOTIFY:
         con = (xcb_colormap_notify_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", colormap=%" PRIu32 ", new=%" PRIu8 ", state=%" PRIu8,
+        fprintf(stderr, ", window=%" PRIu32 ", colormap=%" PRIu32 ", new=%" PRIu8 ", state=%" PRIu8,
                 con->window, con->colormap, con->_new, con->state);
         break;
 
     case XCB_CLIENT_MESSAGE:
         cln = (xcb_client_message_event_t*) event;
-        fprintf(stderr, "window=%" PRIu32 ", type=%" PRIu32
+        fprintf(stderr, ", window=%" PRIu32 ", type=%" PRIu32
                 ", data=%" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32,
                 cln->window, cln->type, cln->data.data32[0], cln->data.data32[1],
                 cln->data.data32[2], cln->data.data32[3], cln->data.data32[4]);
@@ -280,13 +298,13 @@ void log_event(xcb_generic_event_t *event)
 
     case XCB_MAPPING_NOTIFY:
         min = (xcb_mapping_notify_event_t*) event;
-        fprintf(stderr, "request=%" PRIu8 ", first_keycode=%" PRIu8 ", count=%" PRIu8,
+        fprintf(stderr, ", request=%" PRIu8 ", first_keycode=%" PRIu8 ", count=%" PRIu8,
                 min->request, min->first_keycode, min->count);
         break;
 
     case XCB_GE_GENERIC:
         gen = (xcb_ge_generic_event_t*) event;
-        fprintf(stderr, "sequence=%" PRIu16 ", length=%" PRIu32,
+        fprintf(stderr, ", sequence=%" PRIu16 ", length=%" PRIu32,
                 gen->sequence, gen->length);
         break;
     }
@@ -321,11 +339,11 @@ void log_error(xcb_generic_error_t *error, const char *format, ...)
 void log_screen(void)
 {
     LOG("Screen with root %u(width=%u, height=%u, white_pixel=%u, black_pixel=%u)\n",
-            x_screen->root,
-            x_screen->width_in_pixels,
-            x_screen->height_in_pixels,
-            x_screen->white_pixel,
-            x_screen->black_pixel);
+            screen->root,
+            screen->width_in_pixels,
+            screen->height_in_pixels,
+            screen->white_pixel,
+            screen->black_pixel);
 }
 
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -16,12 +16,12 @@
 int main(void)
 {
     /* initialize the X connection, X atoms and create utility windows */
-    if (x_initialize() != OK) {
+    if (initialize_x11() != OK) {
         return ERROR;
     }
 
     /* try to take control of the windows and start managing */
-    if (x_take_control() != OK) {
+    if (take_control() != OK) {
         quit_fensterchef(EXIT_FAILURE);
     }
 
@@ -41,16 +41,16 @@ int main(void)
         quit_fensterchef(EXIT_FAILURE);
     }
 
-    /* prepare the event loop */
-    if (prepare_cycles() != OK) {
-        quit_fensterchef(EXIT_FAILURE);
-    }
-
     /* load the default configuration and the user configuration, this also
      * initializes the keybindings and font
      */
     load_default_configuration();
     reload_user_configuration();
+
+    /* set the signal handlers */
+    if (initialize_signal_handlers() != OK) {
+        quit_fensterchef(EXIT_FAILURE);
+    }
 
     /* set the X properties on the root window */
     synchronize_all_root_properties();

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -58,7 +58,7 @@ void initialize_monitors(void)
         randr_enabled = true;
         randr_event_base = extension->first_event;
 
-        xcb_randr_select_input(connection, x_screen->root,
+        xcb_randr_select_input(connection, screen->root,
                 XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE |
                 XCB_RANDR_NOTIFY_MASK_OUTPUT_CHANGE |
                 XCB_RANDR_NOTIFY_MASK_CRTC_CHANGE |
@@ -162,9 +162,9 @@ Monitor *query_monitors(void)
 
     /* get cookies for later */
     primary_cookie = xcb_randr_get_output_primary(connection,
-            x_screen->root);
+            screen->root);
     resources_cookie = xcb_randr_get_screen_resources_current(connection,
-            x_screen->root);
+            screen->root);
 
     /* get the primary monitor */
     primary = xcb_randr_get_output_primary_reply(connection, primary_cookie,
@@ -303,8 +303,8 @@ void merge_monitors(Monitor *monitors)
 
     if (monitors == NULL) {
         monitors = create_monitor("#Virtual", (uint32_t) -1);
-        monitors->size.width = x_screen->width_in_pixels;
-        monitors->size.height = x_screen->height_in_pixels;
+        monitors->size.width = screen->width_in_pixels;
+        monitors->size.height = screen->height_in_pixels;
     }
 
     /* copy frames from the old monitors to the new ones with same name */

--- a/src/render.c
+++ b/src/render.c
@@ -141,11 +141,11 @@ int initialize_renderer(void)
     }
 
     /* create a graphics context */
-    general_values[0] = x_screen->black_pixel;
-    general_values[1] = x_screen->white_pixel;
+    general_values[0] = screen->black_pixel;
+    general_values[1] = screen->white_pixel;
     error = xcb_request_check(connection,
             xcb_create_gc_checked(connection, stock_objects[STOCK_GC],
-                x_screen->root, XCB_GC_FOREGROUND | XCB_GC_BACKGROUND,
+                screen->root, XCB_GC_FOREGROUND | XCB_GC_BACKGROUND,
                 general_values));
     if (error != NULL) {
         LOG_ERROR(error, "could not create graphics context for notifications");
@@ -153,11 +153,11 @@ int initialize_renderer(void)
     }
 
     /* create a graphics context with inverted colors */
-    general_values[0] = x_screen->white_pixel;
-    general_values[1] = x_screen->black_pixel;
+    general_values[0] = screen->white_pixel;
+    general_values[1] = screen->black_pixel;
     error = xcb_request_check(connection,
             xcb_create_gc_checked(connection,
-                stock_objects[STOCK_INVERTED_GC], x_screen->root,
+                stock_objects[STOCK_INVERTED_GC], screen->root,
                 XCB_GC_FOREGROUND | XCB_GC_BACKGROUND, general_values));
     if (error != NULL) {
         LOG_ERROR(error, "could not create inverted graphics context for notifications");
@@ -165,7 +165,7 @@ int initialize_renderer(void)
     }
 
     /* create a white pen */
-    convert_color_to_xcb_color(&color, x_screen->white_pixel);
+    convert_color_to_xcb_color(&color, screen->white_pixel);
     pen = create_pen(color);
     if (pen == XCB_NONE) {
         return ERROR;
@@ -173,7 +173,7 @@ int initialize_renderer(void)
     stock_objects[STOCK_WHITE_PEN] = create_pen(color);
 
     /* create a black pen */
-    convert_color_to_xcb_color(&color, x_screen->black_pixel);
+    convert_color_to_xcb_color(&color, screen->black_pixel);
     pen = create_pen(color);
     if (pen == XCB_NONE) {
         return ERROR;
@@ -250,7 +250,7 @@ xcb_render_picture_t cache_window_picture(xcb_drawable_t xcb_drawable)
     error = xcb_request_check(connection,
                 xcb_render_create_picture_checked(connection, picture,
                 xcb_drawable,
-                find_visual_format(x_screen->root_visual),
+                find_visual_format(screen->root_visual),
                 XCB_RENDER_CP_POLY_MODE | XCB_RENDER_CP_POLY_EDGE,
                 general_values));
     if (error != NULL) {
@@ -289,8 +289,8 @@ xcb_render_picture_t create_pen(xcb_render_color_t color)
     /* create 1x1 pixmap */
     pixmap = xcb_generate_id(connection);
     error = xcb_request_check(connection, xcb_create_pixmap_checked(connection,
-                x_screen->root_depth, pixmap,
-                x_screen->root, 1, 1));
+                screen->root_depth, pixmap,
+                screen->root, 1, 1));
     if (error != NULL) {
         LOG_ERROR(error, "could not create pixmap");
         return XCB_NONE;
@@ -368,12 +368,12 @@ static FT_Face create_font_face(FcPattern *pattern)
      * multiplying by 254 and then diving by 10 converts the millimeters to
      * inches, adding half the divisor before dividing will round better
      */
-    horizontal_dpi = (FT_UInt) (x_screen->width_in_pixels * 254 +
-            x_screen->width_in_millimeters * 5) /
-        (x_screen->width_in_millimeters * 10);
-    vertical_dpi = (FT_UInt) (x_screen->height_in_pixels * 254 +
-            x_screen->height_in_millimeters * 5) /
-        (x_screen->height_in_millimeters * 10);
+    horizontal_dpi = (FT_UInt) (screen->width_in_pixels * 254 +
+            screen->width_in_millimeters * 5) /
+        (screen->width_in_millimeters * 10);
+    vertical_dpi = (FT_UInt) (screen->height_in_pixels * 254 +
+            screen->height_in_millimeters * 5) /
+        (screen->height_in_millimeters * 10);
     /* try to set the size of the face, we need to multiply by 64 because
      * FT_Set_Char_Size() expects 26.6 fractional points
      */
@@ -619,7 +619,7 @@ static int cache_glyph(uint32_t glyph, FT_Pos *advance)
     free(temporary_bitmap);
 
     if (error != NULL) {
-        LOG_ERROR(error, "could not add glyph U+%8x to the glyphset",
+        LOG_ERROR(error, "could not add glyph U+%08x to the glyphset",
                 (unsigned) glyph);
         return ERROR;
     }

--- a/src/root_properties.c
+++ b/src/root_properties.c
@@ -90,7 +90,7 @@ static void synchronize_supported(void)
     };
 
     /* set all atoms our window manager supports */
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
             ATOM(_NET_SUPPORTED), XCB_ATOM_ATOM, 8 * sizeof(uint32_t),
             SIZE(supported_atoms), supported_atoms);
 }
@@ -116,9 +116,9 @@ static void synchronize_work_area(void)
     }
     rectangle.x = left;
     rectangle.y = top;
-    rectangle.width = x_screen->width_in_pixels - right - left;
-    rectangle.height = x_screen->height_in_pixels - bottom - top;
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+    rectangle.width = screen->width_in_pixels - right - left;
+    rectangle.height = screen->height_in_pixels - bottom - top;
+    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
             ATOM(_NET_WORKAREA), XCB_ATOM_CARDINAL, 8 * sizeof(uint32_t),
             sizeof(rectangle) / sizeof(uint32_t), &rectangle);
 }
@@ -142,44 +142,44 @@ void synchronize_root_property(root_property_t property)
 
     /* the number of desktops, just set it to 1 */
     case ROOT_PROPERTY_NUMBER_OF_DESKTOPS:
-        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
                 ATOM(_NET_NUMBER_OF_DESKTOPS), XCB_ATOM_CARDINAL, 32, 1, &one);
         break;
 
     /* the size of a desktop, we do not support large desktops */
     case ROOT_PROPERTY_DESKTOP_GEOMETRY:
-        geometry.width = x_screen->width_in_pixels;
-        geometry.height = x_screen->height_in_pixels;
-        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+        geometry.width = screen->width_in_pixels;
+        geometry.height = screen->height_in_pixels;
+        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
                 ATOM(_NET_DESKTOP_GEOMETRY), XCB_ATOM_CARDINAL, 32, 2,
                 &geometry);
         break;
 
     /* viewport of each desktop, just set it to (0, 0) for the only desktop */
     case ROOT_PROPERTY_DESKTOP_VIEWPORT:
-        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
                 ATOM(_NET_DESKTOP_VIEWPORT), XCB_ATOM_CARDINAL, 32, 2,
                 &origin);
         break;
 
     /* the currently selected desktop, always 0 */
     case ROOT_PROPERTY_CURRENT_DESKTOP:
-        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
                 ATOM(_NET_CURRENT_DESKTOP), XCB_ATOM_CARDINAL, 32, 1, &zero);
         break;
 
     /* the name of each desktop */
     case ROOT_PROPERTY_DESKTOP_NAMES:
-        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
                 ATOM(_NET_DESKTOP_NAMES), ATOM(UTF8_STRING), 8,
                 strlen(desktop_name), desktop_name);
         break;
 
     /* the currently active window */
     case ROOT_PROPERTY_ACTIVE_WINDOW:
-        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, x_screen->root,
+        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
                 ATOM(_NET_ACTIVE_WINDOW), XCB_ATOM_WINDOW, 32, 1,
-                focus_window == NULL ?  &x_screen->root :
+                focus_window == NULL ?  &screen->root :
                 &focus_window->properties.window);
         break;
 
@@ -193,7 +193,7 @@ void synchronize_root_property(root_property_t property)
      */
     case ROOT_PROPERTY_SUPPORTING_WM_CHECK:
         xcb_change_property(connection, XCB_PROP_MODE_REPLACE,
-                x_screen->root, ATOM(_NET_SUPPORTING_WM_CHECK), XCB_ATOM_WINDOW,
+                screen->root, ATOM(_NET_SUPPORTING_WM_CHECK), XCB_ATOM_WINDOW,
                 32, 1, &check_window);
         break;
 

--- a/src/tiling.c
+++ b/src/tiling.c
@@ -1,39 +1,26 @@
 #include <inttypes.h>
 
 #include "configuration.h"
-#include "fensterchef.h"
-#include "frame.h"
 #include "log.h"
 #include "tiling.h"
 #include "utility.h"
 #include "window.h"
 
-/* Split a frame horizontally or vertically.
- *
- * This cuts the @split_from frame in half and places the next window
- * inside the formed gap. If there is no next window, a gap simply remains.
- */
-void split_frame(Frame *split_from, bool is_split_vert)
+/* Split a frame horizontally or vertically. */
+void split_frame(Frame *split_from, frame_split_direction_t direction)
 {
     Frame *left, *right;
     Frame *next_cur_frame;
     Window *window;
 
+    split_from->split_direction = direction;
+
     left = xcalloc(1, sizeof(*left));
     right = xcalloc(1, sizeof(*right));
 
-    if (is_split_vert) {
-        left->y = split_from->y;
-        left->height = split_from->height / 2;
-        right->y = left->y + left->height;
-        right->height = split_from->height -
-            left->height;
-
-        left->x = split_from->x;
-        left->width = split_from->width;
-        right->x = split_from->x;
-        right->width = split_from->width;
-    } else {
+    switch (direction) {
+    /* left to right split */
+    case FRAME_SPLIT_HORIZONTALLY:
         left->x = split_from->x;
         left->width = split_from->width / 2;
         right->x = left->x + left->width;
@@ -44,6 +31,21 @@ void split_frame(Frame *split_from, bool is_split_vert)
         left->height = split_from->height;
         right->y = split_from->y;
         right->height = split_from->height;
+        break;
+
+    /* top to bottom split */
+    case FRAME_SPLIT_VERTICALLY:
+        left->y = split_from->y;
+        left->height = split_from->height / 2;
+        right->y = left->y + left->height;
+        right->height = split_from->height -
+            left->height;
+
+        left->x = split_from->x;
+        left->width = split_from->width;
+        right->x = split_from->x;
+        right->width = split_from->width;
+        break;
     }
 
     left->window = split_from->window;
@@ -75,6 +77,184 @@ void split_frame(Frame *split_from, bool is_split_vert)
     set_focus_frame(next_cur_frame);
 
     LOG("split %p[%p, %p]\n", (void*) split_from, (void*) left, (void*) right);
+}
+
+/* Get the frame on the left of @frame. */
+Frame *get_left_or_above_frame(Frame *frame,
+        frame_split_direction_t split_direction)
+{
+    Frame *parent;
+
+    while (frame != NULL) {
+        parent = frame->parent;
+        if (parent == NULL) {
+            return NULL;
+        }
+
+        if (parent->split_direction == split_direction) {
+            frame = parent;
+        } else if (parent->left == frame) {
+            frame = parent;
+        } else {
+            return parent->left;
+        }
+    }
+    return NULL;
+}
+
+/* Get the frame on the left of @frame. */
+Frame *get_left_frame(Frame *frame) {
+    return get_left_or_above_frame(frame, FRAME_SPLIT_VERTICALLY);
+}
+
+/* Get the frame above @frame. */
+Frame *get_above_frame(Frame *frame)
+{
+    return get_left_or_above_frame(frame, FRAME_SPLIT_HORIZONTALLY);
+}
+
+/* Get the frame on the left of @frame. */
+Frame *get_right_or_below_frame(Frame *frame,
+        frame_split_direction_t split_direction)
+{
+    Frame *parent;
+
+    while (frame != NULL) {
+        parent = frame->parent;
+        if (parent == NULL) {
+            return NULL;
+        }
+
+        if (parent->split_direction == split_direction) {
+            frame = parent;
+        } else if (parent->right == frame) {
+            frame = parent;
+        } else {
+            return parent->right;
+        }
+    }
+    return NULL;
+}
+
+/* Get the frame on the left of @frame. */
+Frame *get_right_frame(Frame *frame) {
+    return get_right_or_below_frame(frame, FRAME_SPLIT_VERTICALLY);
+}
+
+/* Get the frame above @frame. */
+Frame *get_below_frame(Frame *frame)
+{
+    return get_right_or_below_frame(frame, FRAME_SPLIT_HORIZONTALLY);
+}
+
+/* Get the minimum size the given frame should have. */
+static void get_minimum_frame_size(Frame *frame, Size *size)
+{
+    Size left_size, right_size;
+
+    if (frame->left != NULL) {
+        get_minimum_frame_size(frame->left, &left_size);
+        get_minimum_frame_size(frame->right, &right_size);
+        if (frame->split_direction == FRAME_SPLIT_VERTICALLY) {
+            size->width = MAX(left_size.width, right_size.width);
+            size->height = left_size.height + right_size.height;
+        } else {
+            size->width = left_size.width + right_size.width;
+            size->height = MAX(left_size.height, right_size.height);
+        }
+    } else {
+        size->width = 12;
+        size->height = 12;
+    }
+}
+
+/* Increases the @edge of @frame by @amount. */
+int32_t bump_frame_edge(Frame *frame, frame_edge_t edge, int32_t amount)
+{
+    Frame *right;
+    Size size;
+    int32_t space;
+
+    if (amount == 0) {
+        return 0;
+    }
+
+    switch (edge) {
+    /* delegate left movement to right movement */
+    case FRAME_EDGE_LEFT:
+        frame = get_left_frame(frame);
+        if (frame == NULL) {
+            return 0;
+        }
+        amount = -bump_frame_edge(frame, FRAME_EDGE_RIGHT, -amount);
+        break;
+
+    /* delegate top movement to bottom movement */
+    case FRAME_EDGE_TOP:
+        frame = get_above_frame(frame);
+        if (frame == NULL) {
+            return 0;
+        }
+        amount = -bump_frame_edge(frame, FRAME_EDGE_BOTTOM, -amount);
+        break;
+
+    /* move the frame's right edge */
+    case FRAME_EDGE_RIGHT:
+        right = get_right_frame(frame);
+        if (right == NULL) {
+            return 0;
+        }
+        frame = get_left_frame(right);
+        if (amount < 0) {
+            get_minimum_frame_size(frame, &size);
+            space = size.width - frame->width;
+            if (space >= 0) {
+                return 0;
+            }
+            amount = MAX(amount, space);
+        } else {
+            get_minimum_frame_size(right, &size);
+            space = right->width - size.width;
+            if (space <= 0) {
+                return 0;
+            }
+            amount = MIN(amount, space);
+        }
+        resize_frame(frame, frame->x, frame->y, frame->width + amount,
+                frame->height);
+        resize_frame(right, right->x + amount, right->y, right->width - amount,
+                right->height);
+        break;
+
+    /* move the frame's bottom edge */
+    case FRAME_EDGE_BOTTOM:
+        right = get_below_frame(frame);
+        if (right == NULL) {
+            return 0;
+        }
+        frame = get_above_frame(right);
+        if (amount < 0) {
+            get_minimum_frame_size(frame, &size);
+            space = size.height - frame->height;
+            if (space >= 0) {
+                return 0;
+            }
+            amount = MAX(amount, space);
+        } else {
+            get_minimum_frame_size(right, &size);
+            space = right->height - size.height;
+            if (space <= 0) {
+                return 0;
+            }
+            amount = MIN(amount, space);
+        }
+        resize_frame(frame, frame->x, frame->y, frame->width,
+                frame->height + amount);
+        resize_frame(right, right->x, right->y + amount, right->width,
+                right->height - amount);
+        break;
+    }
+    return amount;
 }
 
 /* Destroys a frame and all sub frames while also unmapping the associated

--- a/src/tiling.c
+++ b/src/tiling.c
@@ -150,9 +150,9 @@ Frame *get_below_frame(Frame *frame)
 /* Get the minimum size the given frame should have. */
 static void get_minimum_frame_size(Frame *frame, Size *size)
 {
-    Size left_size, right_size;
-
     if (frame->left != NULL) {
+        Size left_size, right_size;
+
         get_minimum_frame_size(frame->left, &left_size);
         get_minimum_frame_size(frame->right, &right_size);
         if (frame->split_direction == FRAME_SPLIT_VERTICALLY) {
@@ -163,8 +163,8 @@ static void get_minimum_frame_size(Frame *frame, Size *size)
             size->height = MAX(left_size.height, right_size.height);
         }
     } else {
-        size->width = 12;
-        size->height = 12;
+        size->width = FRAME_MINIMUM_SIZE;
+        size->height = FRAME_MINIMUM_SIZE;
     }
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -41,7 +41,7 @@ Window *create_window(xcb_window_t xcb_window)
         /* still continue */
     }
 
-    x_init_properties(&window->properties, xcb_window);
+    init_window_properties(&window->properties, xcb_window);
 
     set_window_mode(window, predict_window_mode(window), false);
 
@@ -63,7 +63,7 @@ void close_window(Window *window)
     /* if either `WM_DELETE_WINDOW` is not supported or a close was requested
      * twice in a row
      */
-    if (!x_supports_protocol(&window->properties, ATOM(WM_DELETE_WINDOW)) ||
+    if (!supports_protocol(&window->properties, ATOM(WM_DELETE_WINDOW)) ||
             (window->state.was_close_requested && current_time <=
                 window->state.user_request_close_time +
                     REQUEST_CLOSE_MAX_DURATION)) {
@@ -113,10 +113,74 @@ void destroy_window(Window *window)
     free(window);
 }
 
+/* Adjust given @x and @y such that it follows the @window_gravity. */
+void adjust_for_window_gravity(Monitor *monitor, int32_t *x, int32_t *y,
+        uint32_t width, uint32_t height, uint32_t window_gravity)
+{
+    switch (window_gravity) {
+    /* attach to the top left */
+    case XCB_GRAVITY_NORTH_WEST:
+        *x = monitor->position.x;
+        *y = monitor->position.y;
+        break;
+
+    /* attach to the top */
+    case XCB_GRAVITY_NORTH:
+        *y = monitor->position.y;
+        break;
+
+    /* attach to the top right */
+    case XCB_GRAVITY_NORTH_EAST:
+        *x = monitor->position.x + monitor->size.width - width;
+        *y = monitor->position.y;
+        break;
+
+    /* attach to the left */
+    case XCB_GRAVITY_WEST:
+        *x = monitor->position.x;
+        break;
+
+    /* put it into the center */
+    case XCB_GRAVITY_CENTER:
+        *x = monitor->position.x + (monitor->size.width - width) / 2;
+        *y = monitor->position.y + (monitor->size.height - height) / 2;
+        break;
+
+    /* attach to the right */
+    case XCB_GRAVITY_EAST:
+        *x = monitor->position.x + monitor->size.width - width;
+        break;
+
+    /* attach to the bottom left */
+    case XCB_GRAVITY_SOUTH_WEST:
+        *x = monitor->position.x;
+        *y = monitor->position.y + monitor->size.height - height;
+        break;
+
+    /* attach to the bottom */
+    case XCB_GRAVITY_SOUTH:
+        *y = monitor->position.y + monitor->size.height - height;
+        break;
+
+    /* attach to the bottom right */
+    case XCB_GRAVITY_SOUTH_EAST:
+        *x = monitor->position.x + monitor->size.width - width;
+        *y = monitor->position.y + monitor->size.width - height;
+        break;
+
+    /* nothing to do */
+    case XCB_GRAVITY_STATIC:
+        break;
+    }
+}
+
 /* Set the position and size of a window. */
 void set_window_size(Window *window, int32_t x, int32_t y, uint32_t width,
         uint32_t height)
 {
+    width = MAX(width, 1);
+    height = MAX(height, 1);
+
     LOG("configuring size of window %" PRIu32
             " to: %" PRId32 ", %" PRId32 ", %" PRIu32 ", %" PRIu32 "\n",
             window->number, x, y, width, height);
@@ -142,7 +206,7 @@ void set_window_above(Window *window)
     LOG("setting window %" PRIu32 " above all other windows\n", window->number);
 
     /* desktop windows are always at the bottom */
-    if (x_is_window_type(&window->properties,
+    if (has_window_type(&window->properties,
                 ATOM(_NET_WM_WINDOW_TYPE_DESKTOP))) {
         general_values[0] = XCB_STACK_MODE_BELOW;
     } else {
@@ -192,7 +256,7 @@ Window *get_window_of_xcb_window(xcb_window_t xcb_window)
     }
 #ifdef DEBUG
     /* omit log message for the root window */
-    if (xcb_window != x_screen->root) {
+    if (xcb_window != screen->root) {
         LOG("xcb window %" PRIu32 " is not managed\n", xcb_window);
     }
 #endif
@@ -263,7 +327,7 @@ bool does_window_accept_focus(Window *window)
     /* desktop windows are in the background, they are at the bottom and not
      * focusable
      */
-    if (x_is_window_type(&window->properties,
+    if (has_window_type(&window->properties,
                 ATOM(_NET_WM_WINDOW_TYPE_DESKTOP))) {
         return false;
     }

--- a/src/window.c
+++ b/src/window.c
@@ -178,8 +178,24 @@ void adjust_for_window_gravity(Monitor *monitor, int32_t *x, int32_t *y,
 void set_window_size(Window *window, int32_t x, int32_t y, uint32_t width,
         uint32_t height)
 {
-    width = MAX(width, 1);
-    height = MAX(height, 1);
+    width = MAX(width, WINDOW_MINIMUM_SIZE);
+    height = MAX(height, WINDOW_MINIMUM_SIZE);
+
+    /* make it so the window does not become too large and that is stays on
+     * screen
+     */
+    width = MIN(width, WINDOW_MAXIMUM_SIZE);
+    height = MIN(height, WINDOW_MAXIMUM_SIZE);
+    if (x + (int32_t) width < WINDOW_MINIMUM_VISIBLE_SIZE) {
+        x = WINDOW_MINIMUM_VISIBLE_SIZE - width;
+    } else if (x + WINDOW_MINIMUM_VISIBLE_SIZE > screen->width_in_pixels) {
+        x = screen->width_in_pixels - WINDOW_MINIMUM_VISIBLE_SIZE;
+    }
+    if (y + (int32_t) height < WINDOW_MINIMUM_VISIBLE_SIZE) {
+        y = WINDOW_MINIMUM_VISIBLE_SIZE - height;
+    } else if (y + WINDOW_MINIMUM_VISIBLE_SIZE > screen->height_in_pixels) {
+        y = screen->height_in_pixels - WINDOW_MINIMUM_VISIBLE_SIZE;
+    }
 
     LOG("configuring size of window %" PRIu32
             " to: %" PRId32 ", %" PRId32 ", %" PRIu32 ", %" PRIu32 "\n",


### PR DESCRIPTION
Nun können die Edges von Fenstern bewegt werden, wenn ein Bind für
`resize-by` besteht. Für diesen gibt es den neuen Datentyp quad, welcher
aus 4 ganzen Zahlen besteht.
```
Left resize-by 20
Down resize-by 0 0 0 20
```
In diesem Beispiel wird bei Links-drücken die linke Seite des derzeit
ausgewählten Fensters bewegt. Beachte, dass nur `20` da ist und nicht
vier Zahlen. Der parser füllt den Rest mit Nullen auf.

Dazu gibt es default keybindings, zu finden in configuration.c.