### PR TITLE
Window taken system

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -21,6 +21,8 @@ typedef enum {
     ACTION_RELOAD_CONFIGURATION,
     /* closes the currently active window */
     ACTION_CLOSE_WINDOW,
+    /* hides the currently active window */
+    ACTION_MINIMIZE_WINDOW,
     /* go to the next window in the window list */
     ACTION_NEXT_WINDOW,
     /* go to the previous window in the window list */

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -42,9 +42,9 @@ struct configuration_border {
 
 /* gaps settings for the tiling layout */
 struct configuration_gaps {
-    /* width the inner gaps (between frames) */
+    /* width of the inner gaps (between frames) */
     uint32_t inner;
-    /* width the inner gaps (between frames and monitor boundaries) */
+    /* width of the inner gaps (between frames and monitor boundaries) */
     uint32_t outer;
 };
 

--- a/include/root_properties.h
+++ b/include/root_properties.h
@@ -5,6 +5,8 @@
 typedef enum root_property {
     /* _NET_SUPPORTED (supported atoms) */
     ROOT_PROPERTY_SUPPORTED,
+    /* _NET_CLIENT_LIST / _NET_CLINET_LIST_STACKING (list of managed windows) */
+    ROOT_PROPERTY_CLIENT_LIST,
     /* _NET_SUPPORTED (number of desktops) */
     ROOT_PROPERTY_NUMBER_OF_DESKTOPS,
     /* _NET_SUPPORTED (size of the desktop) */

--- a/include/tiling.h
+++ b/include/tiling.h
@@ -3,11 +3,14 @@
 
 #include "frame.h"
 
-/* Increases the @edge of @frame by @amount. */
-int32_t bump_frame_edge(Frame *frame, frame_edge_t edge, int32_t amount);
+/* Fill the frame with the last taken window. */
+void fill_empty_frame(Frame *frame);
 
 /* Split a frame horizontally or vertically. */
 void split_frame(Frame *split_from, frame_split_direction_t direction);
+
+/* Increases the @edge of @frame by @amount. */
+int32_t bump_frame_edge(Frame *frame, frame_edge_t edge, int32_t amount);
 
 /* Remove a frame from the screen and hide the inner windows.
  *

--- a/include/window.h
+++ b/include/window.h
@@ -31,6 +31,9 @@ struct window {
     /* the window's X properties */
     XProperties properties;
 
+    /* the time the window was created */
+    time_t creation_time;
+
     /* the window state */
     WindowState state;
 

--- a/include/window.h
+++ b/include/window.h
@@ -60,6 +60,9 @@ struct window {
      * 1. They were mapped before.
      * 2. They are now invisible.
      * 3. They are a tiling window.
+     *
+     * The list can be thought of growing backward:
+     *   ... <- previous_taken <- last_taken_window
      */
     /* the previous taken window in the taken window linked list */
     Window *previous_taken;

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -54,18 +54,8 @@ bool has_window_border(Window *window);
  */
 void set_window_mode(Window *window, window_mode_t mode, bool force_mode);
 
-/* Show given window but do not assign an id and no size configuring. */
-void show_window_quickly(Window *window);
-
 /* Show the window by positioning it and mapping it to the X server. */
 void show_window(Window *window);
-
-/* Hide a window without focusing another window or filling the tiling gap.
- *
- * The caller must make sure to give another window focus if the given window is
- * the focus window.
- */
-void hide_window_quickly(Window *window);
 
 /* Hide the window by unmapping it from the X server.
  *
@@ -75,5 +65,11 @@ void hide_window_quickly(Window *window);
  * The next window is focused.
  */
 void hide_window(Window *window);
+
+/* Wrapper around `hide_window()` that does not touch the tiling or focus.
+ *
+ * Note: The focus however is removed if @window is the focus.
+ */
+void hide_window_abruptly(Window *window);
 
 #endif

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -54,7 +54,10 @@ bool has_window_border(Window *window);
  */
 void set_window_mode(Window *window, window_mode_t mode, bool force_mode);
 
-/* Show the window by positioning it and mapping it to the X server. */
+/* Show the window by positioning it and mapping it to the X server.
+ *
+ * Note that this removes the given window from the taken window list.
+ */
 void show_window(Window *window);
 
 /* Hide the window by unmapping it from the X server.

--- a/src/action.c
+++ b/src/action.c
@@ -76,7 +76,7 @@ static void run_shell(const char *shell)
 }
 
 /* Run a shell and get the output. */
-static char *run_shell_get_output(const char *shell)
+static char *run_shell_and_get_output(const char *shell)
 {
     FILE *process;
     char *line;
@@ -119,7 +119,7 @@ static void set_active_window(Window *window)
     set_focus_window_with_frame(window);
 }
 
-/* Shows the user the window list and lets the user select a window to focus. */
+/* Show the user the window list and let the user select a window to focus. */
 static void show_window_list(void)
 {
     Window *window;
@@ -400,7 +400,7 @@ void do_action(const Action *action)
 
     /* show a message by getting output from a shell script */
     case ACTION_SHOW_MESSAGE_RUN:
-        shell = run_shell_get_output((char*) action->parameter.string);
+        shell = run_shell_and_get_output((char*) action->parameter.string);
         set_notification((utf8_t*) shell,
                 focus_frame->x + focus_frame->width / 2,
                 focus_frame->y + focus_frame->height / 2);

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -85,37 +85,50 @@ void merge_with_default_key_bindings(struct configuration *configuration)
         xcb_keysym_t key_symbol;
         Action action;
     } default_bindings[] = {
+        /* reload the configuration */
         { XCB_MOD_MASK_SHIFT, XK_r, { .code = ACTION_RELOAD_CONFIGURATION } },
 
+        /* close the active window */
         { 0, XK_q, { .code = ACTION_CLOSE_WINDOW } },
 
+        /* minimize the active window */
+        { 0, XK_minus, { .code = ACTION_MINIMIZE_WINDOW } },
+
+        /* go to the next window in the tiling */
         { 0, XK_n, { .code = ACTION_NEXT_WINDOW } },
         { 0, XK_p, { .code = ACTION_PREVIOUS_WINDOW } },
 
+        /* remove the current tiling frame */
         { 0, XK_r, { .code = ACTION_REMOVE_FRAME } },
 
+        /* toggle between tiling and the previous mode */
         { XCB_MOD_MASK_SHIFT, XK_space, { .code = ACTION_TOGGLE_TILING } },
         { 0, XK_space, { .code = ACTION_TRAVERSE_FOCUS } },
 
+        /* toggle between fullscreen and the previous mode */
         { 0, XK_f, { .code = ACTION_TOGGLE_FULLSCREEN } },
 
+        /* split a frame */
         { 0, XK_v, { .code = ACTION_SPLIT_HORIZONTALLY } },
         { 0, XK_s, { .code = ACTION_SPLIT_VERTICALLY } },
 
+        /* move between frames */
         { 0, XK_k, { .code = ACTION_MOVE_UP } },
         { 0, XK_h, { .code = ACTION_MOVE_LEFT } },
         { 0, XK_l, { .code = ACTION_MOVE_RIGHT } },
         { 0, XK_j, { .code = ACTION_MOVE_DOWN } },
 
-        { 0, XK_Left, { ACTION_RESIZE_BY, {
+        /* resizing the top/left edges of a window */
+        { XCB_MOD_MASK_CONTROL, XK_Left, { ACTION_RESIZE_BY, {
                 .quad = { 20, 0, 0, 0 } } } },
-        { 0, XK_Up, { ACTION_RESIZE_BY, {
+        { XCB_MOD_MASK_CONTROL, XK_Up, { ACTION_RESIZE_BY, {
                 .quad = { 0, 20, 0, 0 } } } },
-        { 0, XK_Right, { ACTION_RESIZE_BY, {
+        { XCB_MOD_MASK_CONTROL, XK_Right, { ACTION_RESIZE_BY, {
                 .quad = { -20, 0, 0, 0 } } } },
-        { 0, XK_Down, { ACTION_RESIZE_BY, {
+        { XCB_MOD_MASK_CONTROL, XK_Down, { ACTION_RESIZE_BY, {
                 .quad = { 0, -20, 0, 0 } } } },
 
+        /* resizing the bottom/right edges of a window */
         { XCB_MOD_MASK_SHIFT, XK_Left, { ACTION_RESIZE_BY, {
                 .quad = { 0, 0, -20, 0 } } } },
         { XCB_MOD_MASK_SHIFT, XK_Up, { ACTION_RESIZE_BY, {
@@ -125,15 +138,17 @@ void merge_with_default_key_bindings(struct configuration *configuration)
         { XCB_MOD_MASK_SHIFT, XK_Down, { ACTION_RESIZE_BY, {
                 .quad = { 0, 0, 0, 20 } } } },
 
-        { XCB_MOD_MASK_CONTROL, XK_Left, { ACTION_RESIZE_BY, {
+        /* move a window */
+        { 0, XK_Left, { ACTION_RESIZE_BY, {
                 .quad = { 20, 0, -20, 0 } } } },
-        { XCB_MOD_MASK_CONTROL, XK_Up, { ACTION_RESIZE_BY, {
+        { 0, XK_Up, { ACTION_RESIZE_BY, {
                 .quad = { 0, 20, 0, -20 } } } },
-        { XCB_MOD_MASK_CONTROL, XK_Right, { ACTION_RESIZE_BY, {
+        { 0, XK_Right, { ACTION_RESIZE_BY, {
                 .quad = { -20, 0, 20, 0 } } } },
-        { XCB_MOD_MASK_CONTROL, XK_Down, { ACTION_RESIZE_BY, {
+        { 0, XK_Down, { ACTION_RESIZE_BY, {
                 .quad = { 0, -20, 0, 20 } } } },
 
+        /* inflate/deflate a window */
         { XCB_MOD_MASK_CONTROL, XK_plus, { ACTION_RESIZE_BY, {
                 .quad = { 10, 10, 10, 10 } } } },
         { XCB_MOD_MASK_CONTROL, XK_minus, { ACTION_RESIZE_BY, {
@@ -141,12 +156,16 @@ void merge_with_default_key_bindings(struct configuration *configuration)
         { XCB_MOD_MASK_CONTROL, XK_equal, { ACTION_RESIZE_BY, {
                 .quad = { 10, 10, 10, 10 } } } },
 
+        /* show the interactive window list */
         { 0, XK_w, { .code = ACTION_SHOW_WINDOW_LIST } },
 
+        /* run xterm */
         { 0, XK_Return, { ACTION_RUN, {
                 .string = (uint8_t*) "/usr/bin/xterm" } } },
 
-        { XCB_MOD_MASK_SHIFT, XK_e, { .code = ACTION_QUIT } }
+        /* quit fensterchef */
+        { XCB_MOD_MASK_CONTROL | XCB_MOD_MASK_SHIFT, XK_e,
+            { .code = ACTION_QUIT } }
     };
 
     struct configuration_key *key;

--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,7 @@ int main(void)
     /* run the main event loop */
     is_fensterchef_running = true;
     while (next_cycle(NULL) == OK) {
-        (void) 0;
+        /* nothing to do */
     }
 
     quit_fensterchef(EXIT_SUCCESS);

--- a/src/tiling.c
+++ b/src/tiling.c
@@ -64,8 +64,7 @@ void split_frame(Frame *split_from, frame_split_direction_t direction)
 
     if (configuration.tiling.auto_fill_void && last_taken_window != NULL) {
         right->window = last_taken_window;
-        reload_frame(right);
-        show_window_quickly(last_taken_window);
+        show_window(last_taken_window);
         last_taken_window = last_taken_window->previous_taken;
     }
 
@@ -263,7 +262,7 @@ static void unmap_and_destroy_recursively(Frame *frame)
         unmap_and_destroy_recursively(frame->left);
         unmap_and_destroy_recursively(frame->right);
     } else if (frame->window != NULL) {
-        hide_window_quickly(frame->window);
+        hide_window_abruptly(frame->window);
     }
     free(frame);
 }

--- a/src/tiling.c
+++ b/src/tiling.c
@@ -10,8 +10,7 @@
 void split_frame(Frame *split_from, frame_split_direction_t direction)
 {
     Frame *left, *right;
-    Frame *next_cur_frame;
-    Window *window;
+    Frame *next_focus_frame;
 
     split_from->split_direction = direction;
 
@@ -58,23 +57,21 @@ void split_frame(Frame *split_from, frame_split_direction_t direction)
     right->parent = split_from;
 
     if (split_from == focus_frame) {
-        next_cur_frame = left;
+        next_focus_frame = left;
     } else {
-        next_cur_frame = focus_frame;
+        next_focus_frame = focus_frame;
     }
 
-    if (configuration.tiling.auto_fill_void) {
-        window = get_next_hidden_window(left->window);
-        if (window != NULL) {
-            /* show window in the right frame */
-            focus_frame = right;
-            show_window(window);
-        }
+    if (configuration.tiling.auto_fill_void && last_taken_window != NULL) {
+        right->window = last_taken_window;
+        reload_frame(right);
+        show_window_quickly(last_taken_window);
+        last_taken_window = last_taken_window->previous_taken;
     }
 
     reload_frame(left);
 
-    set_focus_frame(next_cur_frame);
+    set_focus_frame(next_focus_frame);
 
     LOG("split %p[%p, %p]\n", (void*) split_from, (void*) left, (void*) right);
 }

--- a/src/tiling.c
+++ b/src/tiling.c
@@ -6,6 +6,27 @@
 #include "utility.h"
 #include "window.h"
 
+/* Fill the frame with the last taken window. */
+void fill_empty_frame(Frame *frame)
+{
+    Window *window, *previous_taken;
+
+    /* check if there is something to fill the void with */
+    if (last_taken_window == NULL) {
+        return;
+    }
+
+    /* these need to be saved like this because `show_window()` unlinks the
+     * window from the taken window list
+     */
+    window = last_taken_window;
+    previous_taken = window->previous_taken;
+
+    frame->window = window;
+    show_window(window);
+    last_taken_window = previous_taken;
+}
+
 /* Split a frame horizontally or vertically. */
 void split_frame(Frame *split_from, frame_split_direction_t direction)
 {
@@ -62,10 +83,8 @@ void split_frame(Frame *split_from, frame_split_direction_t direction)
         next_focus_frame = focus_frame;
     }
 
-    if (configuration.tiling.auto_fill_void && last_taken_window != NULL) {
-        right->window = last_taken_window;
-        show_window(last_taken_window);
-        last_taken_window = last_taken_window->previous_taken;
+    if (configuration.tiling.auto_fill_void) {
+        fill_empty_frame(right);
     }
 
     reload_frame(left);

--- a/src/window.c
+++ b/src/window.c
@@ -28,6 +28,8 @@ Window *create_window(xcb_window_t xcb_window)
 
     window = xcalloc(1, sizeof(*window));
 
+    window->creation_time = time(NULL);
+
     /* each window starts with id 0, at the beginning of the linked list */
     window->next = first_window;
     first_window = window;
@@ -313,6 +315,8 @@ void set_window_above(Window *window)
             link_window_into_z_list(below, window);
         }
     }
+
+    synchronize_root_property(ROOT_PROPERTY_CLIENT_LIST);
 }
 
 /* Get the internal window that has the associated xcb window. */

--- a/src/window.c
+++ b/src/window.c
@@ -127,6 +127,8 @@ void unlink_window_from_taken_list(Window *window)
             previous->previous_taken = window->previous_taken;
         }
     }
+
+    window->previous_taken = NULL;
 }
 
 /* Destroys given window and removes it from the window linked list. */


### PR DESCRIPTION
Jetzt gibt es zwei weitere window linked lists. Und eine wurde entfernt.
Die window taken Liste wurde hinzugefügt, sie speichert wenn ein Fenster
aus dem Tiling entfernt wird.

Desweiteren wurde die Z Liste hinzugefügte, welche speichert welches
Fenster über welchem anderen ist.

Die Standardbinds wurden leicht angepasst und die minimize window action
wurde hinzugefügt.

Jetzt ist `hide_window()` und `show_window()` viel sinnvoller gestaltet
und robuster gegen Fehlnutzen. Die Funktionen `*_quickly()` wurden
entfernt, nun gibt es nur noch `hide_window_abruptly()`, um ein Fenster
zu verstecken, wenn der Nutzer es nicht direkt wollte (aber vielleicht
indirekt).

Nun wird das EWMH Atom _NET_CLIENT_LIST benutzt. Externe Programme
können dies nutzen, um eine Liste von Fenstern zu kriegen.