### PR TITLE
Mouse bindings

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -2,6 +2,7 @@
 #define ACTION_H
 
 #include "bits/configuration_parser_data_type.h"
+#include "bits/window_typedef.h"
 
 /* action codes
  *
@@ -23,6 +24,12 @@ typedef enum {
     ACTION_CLOSE_WINDOW,
     /* hides the currently active window */
     ACTION_MINIMIZE_WINDOW,
+    /* focus a window */
+    ACTION_FOCUS_WINDOW,
+    /* start moving a window with the mouse */
+    ACTION_INITIATE_MOVE,
+    /* start resizing a window with the mouse */
+    ACTION_INITIATE_RESIZE,
     /* go to the next window in the window list */
     ACTION_NEXT_WINDOW,
     /* go to the previous window in the window list */
@@ -80,7 +87,13 @@ action_t convert_string_to_action(const char *string);
 /* Get a string version of an action. */
 const char *convert_action_to_string(action_t action);
 
-/* Do the given action. */
-void do_action(const Action *action);
+/* Create a deep copy of given action array. */
+Action *duplicate_actions(Action *actions, uint32_t number_of_actions);
+
+/* Free all given actions and the action array itself. */
+void free_actions(Action *actions, uint32_t number_of_actions);
+
+/* Do the given action on the given window. */
+void do_action(const Action *action, Window *window);
 
 #endif

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -6,7 +6,7 @@
 
 #include "bits/configuration_parser_data_type.h"
 
-#include "configuration.h"
+#include "default_configuration.h"
 #include "utility.h"
 
 /* maximum length of an identifier */
@@ -44,6 +44,10 @@ typedef enum {
     PARSER_ERROR_PREMATURE_LINE_END,
     /* invalid syntax for modifiers */
     PARSER_ERROR_INVALID_MODIFIERS,
+    /* invalid button name */
+    PARSER_ERROR_INVALID_BUTTON,
+    /* invalid button flag */
+    PARSER_ERROR_INVALID_BUTTON_FLAG,
     /* invalid key symbol name */
     PARSER_ERROR_INVALID_KEY_SYMBOL,
     /* invalid value for an action */
@@ -71,6 +75,7 @@ typedef enum parser_label {
     PARSER_LABEL_BORDER,
     PARSER_LABEL_GAPS,
     PARSER_LABEL_NOTIFICATION,
+    PARSER_LABEL_MOUSE,
     PARSER_LABEL_KEYBOARD,
 
     PARSER_LABEL_MAX,
@@ -102,6 +107,8 @@ typedef struct parser {
 
     /* parsed data value */
     union parser_data_value data;
+    /* mousebinding, e.g.: MiddleButton close-window */
+    struct configuration_button button;
     /* keybinding, e.g.: n next-window */
     struct configuration_key key;
 } Parser;

--- a/include/default_configuration.h
+++ b/include/default_configuration.h
@@ -1,0 +1,19 @@
+#ifndef DEFAULT_CONFIGURATION_H
+#define DEFAULT_CONFIGURATION_H
+
+#include "configuration.h"
+
+/* Load the default values into the configuration. */
+void load_default_configuration(void);
+
+/* Puts the mousebindings of the default configuration into @configuration
+ * without overwriting any mousebindings.
+ */
+void merge_with_default_button_bindings(struct configuration *configuration);
+
+/* Puts the keybindings of the default configuration into @configuration without
+ * overwriting any keybindings.
+ */
+void merge_with_default_key_bindings(struct configuration *configuration);
+
+#endif

--- a/include/x11_management.h
+++ b/include/x11_management.h
@@ -351,4 +351,10 @@ bool supports_protocol(XProperties *properties, xcb_atom_t protocol);
 /* Check if @properties includes @window_type. */
 bool has_state(XProperties *properties, xcb_atom_t state);
 
+/* Translate a string to a key symbol.
+ *
+ * *Implemented in string_to_keysym.c*
+ */
+xcb_keysym_t string_to_keysym(const char *string);
+
 #endif

--- a/src/default_configuration.c
+++ b/src/default_configuration.c
@@ -1,0 +1,295 @@
+#include <X11/keysym.h>
+
+#include "default_configuration.h"
+#include "utility.h"
+
+/* the default configuration */
+static const struct configuration default_configuration = {
+    /* default general settings, currently not used for anything */
+    .general = {
+        .unused = 0
+    },
+
+    /* default tiling settings: fill empty frames but never automatically remove
+     * them
+     */
+    .tiling = {
+        .auto_remove_void = false,
+        .auto_fill_void = true
+    },
+
+    /* default font settings: Mono */
+    .font = {
+        .name = (uint8_t*) "Mono"
+    },
+
+    /* default border settings: no borders */
+    .border = {
+        .size = 0,
+    },
+
+    /* default gap settings: no gaps */
+    .gaps = {
+        .inner = 0,
+        .outer = 0
+    },
+
+    /* default notification settings */
+    .notification = {
+        .duration = 3,
+        .padding = 6,
+        .border_color = 0x000000,
+        .border_size = 1,
+        .foreground = 0x000000,
+        .background = 0xffffff,
+    },
+
+    /* default mouse settings: Mod4 as main modifier, see
+     * `merge_with_default_button_bindings()` for the default mouse bindings
+     */
+    .mouse = {
+        .modifiers = XCB_MOD_MASK_4,
+        .ignore_modifiers = XCB_MOD_MASK_LOCK | XCB_MOD_MASK_2 |
+            XCB_MOD_MASK_3 | XCB_MOD_MASK_5,
+    },
+
+    /* default key settings: Mod4 as main modifier, see
+     * `merge_with_default_key_bindings()` for the default key bindings
+     */
+    .keyboard = {
+        .modifiers = XCB_MOD_MASK_4,
+        .ignore_modifiers = XCB_MOD_MASK_LOCK | XCB_MOD_MASK_2 |
+            XCB_MOD_MASK_3 | XCB_MOD_MASK_5,
+    },
+};
+
+/* Puts the mousebindings of the default configuration into @configuration
+ * without overwriting any mousebindings.
+ */
+void merge_with_default_button_bindings(struct configuration *configuration)
+{
+    /* default mousebindings, note that the modifiers are combined with
+     * @configuration->mouse.modifiers
+     */
+    struct {
+        /* the modifiers of the button */
+        uint16_t modifiers;
+        /* the binding flags */
+        uint16_t flags;
+        /* the button to press */
+        xcb_button_t button_index;
+        /* the singular action to execute */
+        Action action;
+    } default_bindings[] = {
+        { 0, 0, 2, { .code = ACTION_CLOSE_WINDOW } },
+    };
+
+    struct configuration_button *button;
+    uint32_t new_count;
+    struct configuration_button *next_button;
+
+    /* get the number of buttons not defined yet */
+    new_count = configuration->mouse.number_of_buttons;
+    for (uint32_t i = 0; i < SIZE(default_bindings); i++) {
+        const uint16_t modifiers = default_bindings[i].modifiers |
+            configuration->mouse.modifiers;
+        button = find_configured_button(configuration, modifiers,
+                default_bindings[i].button_index, default_bindings[i].flags);
+        if (button != NULL) {
+            continue;
+        }
+        new_count++;
+    }
+
+    /* shortcut: no buttons need to be added */
+    if (new_count == configuration->mouse.number_of_buttons) {
+        return;
+    }
+
+    /* add the new buttons on top of the already defined buttons */
+    RESIZE(configuration->mouse.buttons, new_count);
+    next_button =
+        &configuration->mouse.buttons[configuration->mouse.number_of_buttons];
+    for (uint32_t i = 0; i < SIZE(default_bindings); i++) {
+        const uint16_t modifiers = default_bindings[i].modifiers |
+            configuration->mouse.modifiers;
+        button = find_configured_button(configuration, modifiers,
+                default_bindings[i].button_index, default_bindings[i].flags);
+        if (button != NULL) {
+            continue;
+        }
+        next_button->flags = default_bindings[i].flags;
+        next_button->modifiers = modifiers;
+        next_button->index = default_bindings[i].button_index;
+        next_button->actions = xmemdup(&default_bindings[i].action,
+                sizeof(default_bindings[i].action));
+        next_button->number_of_actions = 1;
+        duplicate_data_value(get_action_data_type(next_button->actions[0].code),
+                    &next_button->actions[0].parameter);
+        next_button++;
+    }
+    configuration->mouse.number_of_buttons = new_count;
+}
+
+/* Puts the keybindings of the default configuration into @configuration without
+ * overwriting any keybindings.
+ */
+void merge_with_default_key_bindings(struct configuration *configuration)
+{
+    /* default keybindings, note that the modifiers are combined with
+     * @configuration->keyboard.modifiers
+     */
+    struct {
+        /* the modifiers of the key */
+        uint16_t modifiers;
+        /* the binding flags */
+        uint16_t flags;
+        /* the key symbol */
+        xcb_keysym_t key_symbol;
+        /* the singular action to execute */
+        Action action;
+    } default_bindings[] = {
+        /* reload the configuration */
+        { XCB_MOD_MASK_SHIFT, 0, XK_r, { .code = ACTION_RELOAD_CONFIGURATION } },
+
+        /* close the active window */
+        { 0, 0, XK_q, { .code = ACTION_CLOSE_WINDOW } },
+
+        /* minimize the active window */
+        { 0, 0, XK_minus, { .code = ACTION_MINIMIZE_WINDOW } },
+
+        /* go to the next window in the tiling */
+        { 0, 0, XK_n, { .code = ACTION_NEXT_WINDOW } },
+        { 0, 0, XK_p, { .code = ACTION_PREVIOUS_WINDOW } },
+
+        /* remove the current tiling frame */
+        { 0, 0, XK_r, { .code = ACTION_REMOVE_FRAME } },
+
+        /* toggle between tiling and the previous mode */
+        { XCB_MOD_MASK_SHIFT, 0, XK_space, { .code = ACTION_TOGGLE_TILING } },
+        { 0, 0, XK_space, { .code = ACTION_TRAVERSE_FOCUS } },
+
+        /* toggle between fullscreen and the previous mode */
+        { 0, 0, XK_f, { .code = ACTION_TOGGLE_FULLSCREEN } },
+
+        /* split a frame */
+        { 0, 0, XK_v, { .code = ACTION_SPLIT_HORIZONTALLY } },
+        { 0, 0, XK_s, { .code = ACTION_SPLIT_VERTICALLY } },
+
+        /* move between frames */
+        { 0, 0, XK_k, { .code = ACTION_MOVE_UP } },
+        { 0, 0, XK_h, { .code = ACTION_MOVE_LEFT } },
+        { 0, 0, XK_l, { .code = ACTION_MOVE_RIGHT } },
+        { 0, 0, XK_j, { .code = ACTION_MOVE_DOWN } },
+
+        /* resizing the top/left edges of a window */
+        { XCB_MOD_MASK_CONTROL, 0, XK_Left, { ACTION_RESIZE_BY, {
+                .quad = { 20, 0, 0, 0 } } } },
+        { XCB_MOD_MASK_CONTROL, 0, XK_Up, { ACTION_RESIZE_BY, {
+                .quad = { 0, 20, 0, 0 } } } },
+        { XCB_MOD_MASK_CONTROL, 0, XK_Right, { ACTION_RESIZE_BY, {
+                .quad = { -20, 0, 0, 0 } } } },
+        { XCB_MOD_MASK_CONTROL, 0, XK_Down, { ACTION_RESIZE_BY, {
+                .quad = { 0, -20, 0, 0 } } } },
+
+        /* resizing the bottom/right edges of a window */
+        { XCB_MOD_MASK_SHIFT, 0, XK_Left, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, -20, 0 } } } },
+        { XCB_MOD_MASK_SHIFT, 0, XK_Up, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, 0, -20 } } } },
+        { XCB_MOD_MASK_SHIFT, 0, XK_Right, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, 20, 0 } } } },
+        { XCB_MOD_MASK_SHIFT, 0, XK_Down, { ACTION_RESIZE_BY, {
+                .quad = { 0, 0, 0, 20 } } } },
+
+        /* move a window */
+        { 0, 0, XK_Left, { ACTION_RESIZE_BY, {
+                .quad = { 20, 0, -20, 0 } } } },
+        { 0, 0, XK_Up, { ACTION_RESIZE_BY, {
+                .quad = { 0, 20, 0, -20 } } } },
+        { 0, 0, XK_Right, { ACTION_RESIZE_BY, {
+                .quad = { -20, 0, 20, 0 } } } },
+        { 0, 0, XK_Down, { ACTION_RESIZE_BY, {
+                .quad = { 0, -20, 0, 20 } } } },
+
+        /* inflate/deflate a window */
+        { XCB_MOD_MASK_CONTROL, 0, XK_plus, { ACTION_RESIZE_BY, {
+                .quad = { 10, 10, 10, 10 } } } },
+        { XCB_MOD_MASK_CONTROL, 0, XK_minus, { ACTION_RESIZE_BY, {
+                .quad = { -10, -10, -10, -10 } } } },
+        { XCB_MOD_MASK_CONTROL, 0, XK_equal, { ACTION_RESIZE_BY, {
+                .quad = { 10, 10, 10, 10 } } } },
+
+        /* show the interactive window list */
+        { 0, 0, XK_w, { .code = ACTION_SHOW_WINDOW_LIST } },
+
+        /* run xterm */
+        { 0, 0, XK_Return, { ACTION_RUN, {
+                .string = (uint8_t*) "/usr/bin/xterm" } } },
+
+        /* quit fensterchef */
+        { XCB_MOD_MASK_CONTROL | XCB_MOD_MASK_SHIFT, 0, XK_e,
+            { .code = ACTION_QUIT } }
+    };
+
+    struct configuration_key *key;
+    uint32_t new_count;
+    struct configuration_key *next_key;
+
+    /* get the number of keys not defined yet */
+    new_count = configuration->keyboard.number_of_keys;
+    for (uint32_t i = 0; i < SIZE(default_bindings); i++) {
+        const uint16_t modifiers = default_bindings[i].modifiers |
+            configuration->keyboard.modifiers;
+        key = find_configured_key(configuration, modifiers,
+                default_bindings[i].key_symbol, default_bindings[i].flags);
+        if (key != NULL) {
+            continue;
+        }
+        new_count++;
+    }
+
+    /* shortcut: no keys need to be added */
+    if (new_count == configuration->keyboard.number_of_keys) {
+        return;
+    }
+
+    /* add the new keys on top of the already defined keys */
+    RESIZE(configuration->keyboard.keys, new_count);
+    next_key =
+        &configuration->keyboard.keys[configuration->keyboard.number_of_keys];
+    for (uint32_t i = 0; i < SIZE(default_bindings); i++) {
+        const uint16_t modifiers = default_bindings[i].modifiers |
+            configuration->keyboard.modifiers;
+        key = find_configured_key(configuration, modifiers,
+                default_bindings[i].key_symbol, default_bindings[i].flags);
+        if (key != NULL) {
+            continue;
+        }
+        next_key->flags = default_bindings[i].flags;
+        next_key->modifiers = modifiers;
+        next_key->key_symbol = default_bindings[i].key_symbol;
+        next_key->actions = xmemdup(&default_bindings[i].action,
+                sizeof(default_bindings[i].action));
+        next_key->number_of_actions = 1;
+        duplicate_data_value(get_action_data_type(next_key->actions[0].code),
+                    &next_key->actions[0].parameter);
+        next_key++;
+    }
+    configuration->keyboard.number_of_keys = new_count;
+}
+
+/* Load the default values into the configuration. */
+void load_default_configuration(void)
+{
+    struct configuration configuration;
+
+    /* create a duplicate of the default configuration */
+    configuration = default_configuration;
+    duplicate_configuration(&configuration);
+
+    /* add the default key bindings */
+    merge_with_default_key_bindings(&configuration);
+
+    set_configuration(&configuration);
+}

--- a/src/event.c
+++ b/src/event.c
@@ -7,13 +7,14 @@
 #include <xcb/randr.h>
 
 #include "configuration.h"
+#include "event.h"
 #include "fensterchef.h"
 #include "frame.h"
-#include "event.h"
 #include "keymap.h"
 #include "log.h"
 #include "monitor.h"
 #include "root_properties.h"
+#include "tiling.h"
 #include "utility.h"
 #include "window.h"
 
@@ -123,11 +124,12 @@ int next_cycle(int (*callback)(int cycle_when, xcb_generic_event_t *event))
     return OK;
 }
 
-/* Start resizing given popup window. */
+/* Start moving/resizing given popup window. */
 void initiate_window_move_resize(Window *window,
         wm_move_resize_direction_t direction,
         int32_t start_x, int32_t start_y)
 {
+    /* a window is alread being moved/resized */
     if (move_resize.window != NULL) {
         return;
     }
@@ -211,19 +213,79 @@ static void handle_map_request(xcb_map_request_event_t *event)
 static void handle_button_press(xcb_button_press_event_t *event)
 {
     Window *window;
+    struct configuration_button *button;
 
     if (move_resize.window != NULL) {
         cancel_window_move_resize();
         return;
     }
 
-    window = get_window_of_xcb_window(event->child);
-    if (window == NULL) {
-        return;
+    if (event->child == 0) {
+        window = NULL;
+    } else {
+        window = get_window_of_xcb_window(event->child);
+        if (window == NULL) {
+            return;
+        }
     }
 
-    initiate_window_move_resize(window, _NET_WM_MOVERESIZE_MOVE,
-            event->root_x, event->root_y);
+    button = find_configured_button(&configuration, event->state,
+            event->detail, 0);
+    if (button != NULL) {
+        LOG("performing %" PRIu32 " action(s)\n", button->number_of_actions);
+        for (uint32_t i = 0; i < button->number_of_actions; i++) {
+            LOG("performing action %s\n",
+                    convert_action_to_string(button->actions[i].code));
+            do_action(&button->actions[i], window);
+        }
+
+        /* make the event pass through to the underlying window */
+        if ((button->flags & BINDING_FLAG_TRANSPARENT)) {
+            xcb_allow_events(connection, XCB_ALLOW_REPLAY_POINTER, event->time);
+            return;
+        }
+    }
+}
+
+/* Button releases are only sent when we grabbed them. This only happens
+ * when a popup window is being moved/resized.
+ */
+static void handle_button_release(xcb_button_release_event_t *event)
+{
+    Window *window;
+    struct configuration_button *button;
+
+    if (event->child == 0) {
+        window = NULL;
+    } else {
+        window = get_window_of_xcb_window(event->child);
+        if (window == NULL) {
+            return;
+        }
+    }
+
+    if (move_resize.window != NULL) {
+        /* release mouse events back to the applications */
+        xcb_ungrab_pointer(connection, XCB_CURRENT_TIME);
+        move_resize.window = NULL;
+    }
+
+    button = find_configured_button(&configuration, event->state,
+            event->detail, BINDING_FLAG_RELEASE);
+    if (button != NULL) {
+        LOG("performing %" PRIu32 " action(s)\n", button->number_of_actions);
+        for (uint32_t i = 0; i < button->number_of_actions; i++) {
+            LOG("performing action %s\n",
+                    convert_action_to_string(button->actions[i].code));
+            do_action(&button->actions[i], window);
+        }
+
+        /* make the event pass through to the underlying window */
+        if ((button->flags & BINDING_FLAG_TRANSPARENT)) {
+            xcb_allow_events(connection, XCB_ALLOW_REPLAY_POINTER, event->time);
+            return;
+        }
+    }
 }
 
 /* Motion notifications (mouse move events) are only sent when we grabbed them.
@@ -232,8 +294,17 @@ static void handle_button_press(xcb_button_press_event_t *event)
 static void handle_motion_notify(xcb_motion_notify_event_t *event)
 {
     Rectangle new_geometry;
+    Frame *frame;
 
     if (move_resize.window == NULL) {
+        return;
+    }
+
+    if (move_resize.direction == 0) {
+        /* TODO: figure out the best direction */
+        move_resize.direction = _NET_WM_MOVERESIZE_MOVE;
+        move_resize.start.x = event->root_x;
+        move_resize.start.y = event->root_y;
         return;
     }
 
@@ -301,23 +372,24 @@ static void handle_motion_notify(xcb_motion_notify_event_t *event)
     case _NET_WM_MOVERESIZE_CANCEL:
         break;
     }
-    /* set the window position to the moved position */
-    set_window_size(move_resize.window,
-            new_geometry.x,
-            new_geometry.y,
-            new_geometry.width,
-            new_geometry.height);
-}
 
-/* Button releases are only sent when we grabbed them. This only happens
- * when a popup window is being moved/resized.
- */
-static void handle_button_release(xcb_button_release_event_t *event)
-{
-    (void) event;
-    /* release mouse events back to the applications */
-    xcb_ungrab_pointer(connection, XCB_CURRENT_TIME);
-    move_resize.window = NULL;
+    frame = get_frame_of_window(move_resize.window);
+    if (frame != NULL) {
+        bump_frame_edge(frame, FRAME_EDGE_LEFT,
+                move_resize.window->position.x - new_geometry.x);
+        bump_frame_edge(frame, FRAME_EDGE_TOP,
+                move_resize.window->position.y - new_geometry.y);
+        bump_frame_edge(frame, FRAME_EDGE_RIGHT,
+                new_geometry.width - move_resize.window->size.width);
+        bump_frame_edge(frame, FRAME_EDGE_BOTTOM,
+                new_geometry.height - move_resize.window->size.height);
+    } else {
+        set_window_size(move_resize.window,
+                new_geometry.x,
+                new_geometry.y,
+                new_geometry.width,
+                new_geometry.height);
+    }
 }
 
 /* Property notifications are sent when a window property changes. */
@@ -381,19 +453,50 @@ static void handle_destroy_notify(xcb_destroy_notify_event_t *event)
     }
 }
 
-/* Key press events are sent when a grabbed key is triggered. */
+/* Key press events are sent when a grabbed key is pressed. */
 void handle_key_press(xcb_key_press_event_t *event)
 {
     struct configuration_key *key;
 
     key = find_configured_key(&configuration, event->state,
-            get_keysym(event->detail));
+            get_keysym(event->detail), 0);
     if (key != NULL) {
         LOG("performing %" PRIu32 " action(s)\n", key->number_of_actions);
         for (uint32_t i = 0; i < key->number_of_actions; i++) {
             LOG("performing action %s\n",
                     convert_action_to_string(key->actions[i].code));
-            do_action(&key->actions[i]);
+            do_action(&key->actions[i], focus_window);
+        }
+
+        /* make the event pass through to the focused client */
+        if ((key->flags & BINDING_FLAG_TRANSPARENT)) {
+            xcb_allow_events(connection, XCB_ALLOW_REPLAY_KEYBOARD,
+                    event->time);
+            return;
+        }
+    }
+}
+
+/* Key release events are sent when a grabbed key is released. */
+void handle_key_release(xcb_key_release_event_t *event)
+{
+    struct configuration_key *key;
+
+    key = find_configured_key(&configuration, event->state,
+            get_keysym(event->detail), BINDING_FLAG_RELEASE);
+    if (key != NULL) {
+        LOG("performing %" PRIu32 " action(s)\n", key->number_of_actions);
+        for (uint32_t i = 0; i < key->number_of_actions; i++) {
+            LOG("performing action %s\n",
+                    convert_action_to_string(key->actions[i].code));
+            do_action(&key->actions[i], focus_window);
+        }
+
+        /* make the event pass through to the focused client */
+        if ((key->flags & BINDING_FLAG_TRANSPARENT)) {
+            xcb_allow_events(connection, XCB_ALLOW_REPLAY_KEYBOARD,
+                    event->time);
+            return;
         }
     }
 }
@@ -545,16 +648,22 @@ void handle_event(xcb_generic_event_t *event)
     /* a mouse button was pressed */
     case XCB_BUTTON_PRESS:
         handle_button_press((xcb_button_press_event_t*) event);
-        break;
-
-    /* the mouse was moved */
-    case XCB_MOTION_NOTIFY:
-        handle_motion_notify((xcb_motion_notify_event_t*) event);
+        /* continue processing pointer events normally */
+        xcb_allow_events(connection, XCB_ALLOW_ASYNC_POINTER,
+                ((xcb_button_press_event_t*) event)->time);
         break;
 
     /* a mouse button was released */
     case XCB_BUTTON_RELEASE:
         handle_button_release((xcb_button_release_event_t*) event);
+        /* continue processing pointer events normally */
+        xcb_allow_events(connection, XCB_ALLOW_ASYNC_POINTER,
+                ((xcb_button_release_event_t*) event)->time);
+        break;
+
+    /* the mouse was moved */
+    case XCB_MOTION_NOTIFY:
+        handle_motion_notify((xcb_motion_notify_event_t*) event);
         break;
 
     /* a window changed a property */
@@ -585,6 +694,17 @@ void handle_event(xcb_generic_event_t *event)
     /* a key was pressed */
     case XCB_KEY_PRESS:
         handle_key_press((xcb_key_press_event_t*) event);
+        /* continue processing keyboard events normally */
+        xcb_allow_events(connection, XCB_ALLOW_ASYNC_KEYBOARD,
+                ((xcb_key_press_event_t*) event)->time);
+        break;
+
+    /* a key was released */
+    case XCB_KEY_RELEASE:
+        handle_key_release((xcb_key_release_event_t*) event);
+        /* continue processing keyboard events normally */
+        xcb_allow_events(connection, XCB_ALLOW_ASYNC_KEYBOARD,
+                ((xcb_key_release_event_t*) event)->time);
         break;
 
     /* keyboard mapping changed */

--- a/src/frame.c
+++ b/src/frame.c
@@ -38,6 +38,7 @@ Frame *get_frame_at_position(int32_t x, int32_t y)
                     frame = frame->right;
                     continue;
                 }
+                return NULL;
             }
             return frame;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include "configuration.h"
+#include "default_configuration.h"
 #include "event.h"
 #include "fensterchef.h"
 #include "frame.h"

--- a/src/string_to_keysym.c
+++ b/src/string_to_keysym.c
@@ -1,0 +1,12 @@
+#include <xcb/xcb.h>
+
+#include <X11/Xlib.h> // XStringToKeysym
+
+/* TODO: extract necessary code out of XStringToKeysym, could be fun */
+
+/* Translate a string to a key symbol. */
+xcb_keysym_t string_to_keysym(const char *string)
+{
+    return XStringToKeysym(string);
+}
+

--- a/src/window_list.c
+++ b/src/window_list.c
@@ -317,10 +317,14 @@ Window *select_window_from_list(void)
     /* show the window list window on screen */
     xcb_map_window(connection, window_list_window);
 
-    /* take control of the event loop */
+    /* if this is called from a KeyPress event, we need to unfreeze the keyboard
+     * first to receive key events
+     */
+    xcb_allow_events(connection, XCB_ALLOW_ASYNC_KEYBOARD, XCB_CURRENT_TIME);
     window_list.is_open = true;
+    /* take control of the event loop */
     while (next_cycle(window_list_callback) == OK) {
-        (void) 0;
+        /* nothing to be done */
     }
     window_list.is_open = false;
 

--- a/src/window_state.c
+++ b/src/window_state.c
@@ -326,18 +326,18 @@ void set_window_mode(Window *window, window_mode_t mode, bool force_mode)
         }
 
         switch (mode) {
-        case WINDOW_MODE_TILING: {
-            Window *const old_window = focus_frame->window;
+        case WINDOW_MODE_TILING:
+            if (focus_frame->window == focus_window) {
+                set_focus_window(window);
+            }
+
+            if (focus_frame->window != NULL) {
+                hide_window_abruptly(focus_frame->window);
+            }
 
             focus_frame->window = window;
             reload_frame(focus_frame);
-
-            set_focus_window(window);
-
-            if (old_window != NULL) {
-                hide_window_abruptly(old_window);
-            }
-        } break;
+            break;
 
         case WINDOW_MODE_POPUP:
             configure_popup_size(window);

--- a/src/x11_management.c
+++ b/src/x11_management.c
@@ -162,11 +162,6 @@ int initialize_x11(void)
     if (create_utility_windows() != OK) {
         return ERROR;
     }
-
-    /* grabs ALT+Button for moving popup windows */
-    xcb_grab_button(connection, 0, screen->root, XCB_EVENT_MASK_BUTTON_PRESS |
-            XCB_EVENT_MASK_BUTTON_RELEASE, XCB_GRAB_MODE_ASYNC,
-            XCB_GRAB_MODE_ASYNC, screen->root, XCB_NONE, 1, XCB_MOD_MASK_1);
     return OK;
 }
 


### PR DESCRIPTION
Nun kann `[mouse]` in der Konfiguration definiert werden und Mouse
Bindings hinzugefügt werden. Es wurden auch Flags zu Bindings
hinzugefügt, um zu entscheiden wann und wie der Bind gehandlet werden
soll. Z.B.:
```
[mouse]
modifiers Super
Button1 initiate-move

modifiers None
Button1 --transparent focus-window
```
Wenn nun Super+Button1 auf ein Fenster gedrückt wird, kann man es mit
Bewegung der Maus, solange man nicht loslässt oder einen anderen Mouse
Button drückt, bewegen.
Und wenn Button1 auf ein Fenster gedrückt wird, dann wird es fokussiert
UND das Fenster selbst kriegt auch das Event.

default_configuration.c wurde von configuration.c abgespaltet.