### PR TITLE
query existing windows

### DIFF
--- a/include/x11_management.h
+++ b/include/x11_management.h
@@ -332,8 +332,16 @@ int initialize_x11(void);
 
 /* Try to take control of the window manager role (also initialize the
  * fensterchef windows).
+ *
+ * Call this after `initialize_x11()`
  */
 int take_control(void);
+
+/* Go through all already existing windows and manage them.
+ *
+ * Call this after the `initialize_monitors()`.
+ */
+void query_existing_windows(void);
 
 /* Set the initial root window properties. */
 void initialize_root_properties(void);

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,9 @@ int main(void)
     load_default_configuration();
     reload_user_configuration();
 
+    /* manage the windows that are already there */
+    query_existing_windows();
+
     /* before entering the loop, flush all the initialization calls */
     xcb_flush(connection);
 

--- a/src/window_list.c
+++ b/src/window_list.c
@@ -28,14 +28,16 @@ int initialize_window_list(void)
     const char *window_list_name = "[fensterchef] window list";
 
     window_list.client.id = xcb_generate_id(connection);
+    /* indicate to not manage the window */
+    general_values[0] = true;
     /* get key press events, focus change events and expose events */
-    general_values[0] = XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_EXPOSURE |
+    general_values[1] = XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_EXPOSURE |
         XCB_EVENT_MASK_FOCUS_CHANGE;
     error = xcb_request_check(connection, xcb_create_window_checked(connection,
                 XCB_COPY_FROM_PARENT, window_list.client.id,
                 screen->root, -1, -1, 1, 1, 0,
                 XCB_WINDOW_CLASS_INPUT_OUTPUT, XCB_COPY_FROM_PARENT,
-                XCB_CW_EVENT_MASK, general_values));
+                XCB_CW_OVERRIDE_REDIRECT | XCB_CW_EVENT_MASK, general_values));
     if (error != NULL) {
         LOG_ERROR("could not create window list window: %E\n", error);
         free(error);


### PR DESCRIPTION
Now `query_existing_windows()` is implemented and called in `main()` to manage the already existing windows.