### PR TITLE
Before release fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ SRC := src
 BUILD := build
 RELEASE := release
 
+BINARY := /usr/bin/fensterchef
+MANUAL_PAGE := /usr/share/man/man1/fensterchef.1.gz
+
 # Find all source files
 SOURCES := $(shell find $(SRC) -name '*.c')
 # Get all corresponding object paths
@@ -94,12 +97,12 @@ $(RELEASE)/fensterchef.1.gz: man/fensterchef.1
 	gzip --best -c man/fensterchef.1 > $@
 
 install: $(RELEASE)/fensterchef.1.gz release
-	install $(RELEASE)/fensterchef /usr/bin/fensterchef
-	install $(RELEASE)/fensterchef.1.gz /usr/share/man/man1/fensterchef.1.gz
+	install $(RELEASE)/fensterchef $(BINARY)
+	install $(RELEASE)/fensterchef.1.gz $(MANUAL_PAGE)
 
 uninstall:
-	rm /usr/bin/fensterchef
-	rm /usr/share/man/man1/fensterchef.1.gz
+	rm $(BINARY)
+	rm $(MANUAL_PAGE)
 
 clean:
 	rm -rf $(BUILD)

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ Now you have the **fensterchef** executable and the manual page.
 If you are using a login manager, you can simply put this at the end of your `~/.xsession`:
 ```
 mkdir -p ~/.local/share/fensterchef
-exec /usr/bin/fensterchef -dinfo > ~/.local/share/fensterchef
+exec /usr/bin/fensterchef -dinfo 2>~/.local/share/fensterchef
 ```
 Alternatively put it this into the `~/.xinitrc`.
 
-*How to get fensterchef to run exactly varies on your environment*
+*How to get fensterchef to run exactly varies on your environment.*
 
 ## Bugs
 
 Report any issues directly to us over the Github issues tab.
+
+An issue should start with the version, the rest is up to you. Try to add steps
+to reproduce and the relevant excerpts from the log.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Then simply type the following and enter your password.
 sudo make install
 ```
 
-Now you have the **fensterchef** executable and the manual page.
+Now you have the **fensterchef** executable (`/usr/bin/fensterchef`)
+and the manual page (`/usr/share/man/man1/fensterchef.1.gz`).
 
 If you are using a login manager, you can simply put this at the end of your `~/.xsession`:
 ```

--- a/include/action.h
+++ b/include/action.h
@@ -52,14 +52,14 @@ typedef enum {
     ACTION_SPLIT_HORIZONTALLY,
     /* split the current frame vertically */
     ACTION_SPLIT_VERTICALLY,
-    /* move to the frame above the current one */
-    ACTION_MOVE_UP,
-    /* move to the frame left of the current one */
-    ACTION_MOVE_LEFT,
-    /* move to the frame right of the current one */
-    ACTION_MOVE_RIGHT,
-    /* move to the frame below the current one */
-    ACTION_MOVE_DOWN,
+    /* move the focus to the above frame */
+    ACTION_FOCUS_UP,
+    /* move the focus to the left frame */
+    ACTION_FOCUS_LEFT,
+    /* move the focus to the right frame */
+    ACTION_FOCUS_RIGHT,
+    /* move the focus to the frame below */
+    ACTION_FOCUS_DOWN,
     /* exchange the current frame with the above one */
     ACTION_EXCHANGE_UP,
     /* exchange the current frame with the left one */
@@ -78,7 +78,7 @@ typedef enum {
     ACTION_SHOW_MESSAGE_RUN,
     /* resize the edges of the current window */
     ACTION_RESIZE_BY,
-    /* quits fensterchef */
+    /* quit fensterchef */
     ACTION_QUIT,
 
     /* not a real action */

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -9,8 +9,17 @@
 
 /* general settings */
 struct configuration_general {
-    /* currently no members */
-    uint32_t unused;
+    /* 0 to 100: percentage for the overlapping to consider when moving from one
+     * monitor to another */
+    uint32_t move_overlap;
+};
+
+/* startup actions */
+struct configuration_startup {
+    /* the list of actions to run on start */
+    Action *actions;
+    /* the number of actions */
+    uint32_t number_of_actions;
 };
 
 /* tiling settings */
@@ -122,6 +131,8 @@ struct configuration_keyboard {
 extern struct configuration {
     /* general settings */
     struct configuration_general general;
+    /* startup actions */
+    struct configuration_startup startup;
     /* general settings */
     struct configuration_tiling tiling;
     /* font settings */

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -12,7 +12,7 @@
 struct configuration_general {
     /* 0 to 100: percentage for the overlapping to consider when moving from one
      * monitor to another */
-    uint32_t move_overlap;
+    uint32_t overlap_percentage;
 };
 
 /* startup actions */

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -6,6 +6,7 @@
 
 #include "action.h"
 #include "keymap.h"
+#include "utility.h"
 
 /* general settings */
 struct configuration_general {
@@ -49,9 +50,9 @@ struct configuration_border {
 /* gaps settings for the tiling layout */
 struct configuration_gaps {
     /* width of the inner gaps (between frames) */
-    uint32_t inner;
+    Extents inner;
     /* width of the inner gaps (between frames and monitor boundaries) */
-    uint32_t outer;
+    Extents outer;
 };
 
 /* notification window settings */
@@ -92,7 +93,7 @@ struct configuration_button {
 struct configuration_mouse {
     /* how many pixels off the edges of windows should be used for resizing */
     int32_t resize_tolerance;
-    /* the modifier key applied for all keys (applied at the parsing step) */
+    /* the modifier key for all buttons (applied at the parsing step) */
     uint16_t modifiers;
     /* the modifiers to ignore */
     uint16_t ignore_modifiers;
@@ -117,7 +118,7 @@ struct configuration_key {
 
 /* keyboard settings */
 struct configuration_keyboard {
-    /* the modifier key applied for all keys (applied at the parsing step) */
+    /* the modifier key for all keys (applied at the parsing step) */
     uint16_t modifiers;
     /* the modifiers to ignore */
     uint16_t ignore_modifiers;
@@ -143,9 +144,9 @@ extern struct configuration {
     struct configuration_gaps gaps;
     /* notifiaction window settings */
     struct configuration_notification notification;
-    /* mouse settings / mousebindings */
+    /* mouse settings / button bindings */
     struct configuration_mouse mouse;
-    /* keyboard settings / keybindings */
+    /* keyboard settings / key bindings */
     struct configuration_keyboard keyboard;
 } configuration;
 

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -60,7 +60,7 @@ typedef enum {
 
 /* labels with form "[<name>]"
  *
- * NOTE: After editing this enum, also edit the `label_strings[]` array in
+ * NOTE: After editing this enum, also edit the `labels[]` array in
  * `configuration_parser.c`.
  * To add variables to the label, edit `variables[]` in `parse_line()` and also
  * add it to the configuration in `configuration.c` AND add a default option in
@@ -72,6 +72,7 @@ typedef enum parser_label {
     PARSER_FIRST_LABEL,
 
     PARSER_LABEL_GENERAL = PARSER_FIRST_LABEL,
+    PARSER_LABEL_STARTUP,
     PARSER_LABEL_TILING,
     PARSER_LABEL_FONT,
     PARSER_LABEL_BORDER,

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -42,6 +42,8 @@ typedef enum {
     PARSER_ERROR_BAD_COLOR_FORMAT,
     /* a line is terminated but tokens were expected first */
     PARSER_ERROR_PREMATURE_LINE_END,
+    /* invalid number of integers for a quad */
+    PARSER_ERROR_INVALID_QUAD,
     /* invalid syntax for modifiers */
     PARSER_ERROR_INVALID_MODIFIERS,
     /* invalid button name */

--- a/include/event.h
+++ b/include/event.h
@@ -19,6 +19,12 @@ extern bool has_client_list_changed;
 /* Create a signal handler for `SIGALRM`. */
 int initialize_signal_handlers(void);
 
+/* Set the client list root property. */
+void synchronize_client_list(void);
+
+/* Synchronize the local data with the X server. */
+void synchronize_with_server(void);
+
 /* Runs the next cycle of the event loop. This handles signals and all events
  * that are currently queued.
  *

--- a/include/frame.h
+++ b/include/frame.h
@@ -8,6 +8,8 @@
 #include "bits/frame_typedef.h"
 #include "bits/window_typedef.h"
 
+#include "utility.h"
+
 /* the minimum width or height of a frame */
 #define FRAME_MINIMUM_SIZE 12
 
@@ -82,6 +84,9 @@ void resize_frame(Frame *frame, int32_t x, int32_t y,
  * Note that this empties @with.
  */
 void replace_frame(Frame *frame, Frame *with);
+
+/* Get the gaps the frame applies to its inner window. */
+void get_frame_gaps(Frame *frame, Extents *gaps);
 
 /* Resizes the inner window to fit within the frame. */
 void reload_frame(Frame *frame);

--- a/include/log.h
+++ b/include/log.h
@@ -7,13 +7,13 @@
 
 typedef enum {
     /* everything gets logged */
-    SEVERITY_ALL,
+    LOG_SEVERITY_ALL,
     /* only information gets logged */
-    SEVERITY_INFO,
+    LOG_SEVERITY_INFO,
     /* only errors get logged */
-    SEVERITY_ERROR,
+    LOG_SEVERITY_ERROR,
     /* log nothing */
-    SEVERITY_NOTHING,
+    LOG_SEVERITY_NOTHING,
 } log_severity_t;
 
 /* the severity of the logging */
@@ -45,11 +45,11 @@ extern log_severity_t log_severity;
 
 /* wrappers around `log_formatted` for different severities */
 #define LOG_VERBOSE(...) \
-    log_formatted(SEVERITY_ALL, __FILE__, __LINE__, __VA_ARGS__)
+    log_formatted(LOG_SEVERITY_ALL, __FILE__, __LINE__, __VA_ARGS__)
 #define LOG(...) \
-    log_formatted(SEVERITY_INFO, __FILE__, __LINE__, __VA_ARGS__)
+    log_formatted(LOG_SEVERITY_INFO, __FILE__, __LINE__, __VA_ARGS__)
 #define LOG_ERROR(...) \
-    log_formatted(SEVERITY_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+    log_formatted(LOG_SEVERITY_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 
 /* printf format specifiers that can be used */
 #define PRINTF_FORMAT_SPECIFIERS "diuoxfegcsp"

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -47,6 +47,9 @@ Monitor *get_monitor_from_rectangle(int32_t x, int32_t y,
 Monitor *get_monitor_from_rectangle_or_primary(int32_t x, int32_t y,
         uint32_t width, uint32_t height);
 
+/* Get a window covering given monitor. */
+Window *get_window_covering_monitor(Monitor *monitor);
+
 /* Gets a list of monitors that are associated to the screen.
  *
  * @return NULL when randr is not supported or when there are no monitors.

--- a/include/render.h
+++ b/include/render.h
@@ -36,16 +36,16 @@ extern uint32_t stock_objects[STOCK_MAX];
 /* Initialize the graphical stock objects that can be used for rendering. */
 int initialize_renderer(void);
 
-/* Frees all resources associated to rendering. */
+/* Free all resources associated to rendering. */
 void deinitialize_renderer(void);
 
-/* Creates a picture for the given window (or retrieves it from the cache). */
+/* Create a picture for the given window (or retrieves it from the cache). */
 xcb_render_picture_t cache_window_picture(xcb_drawable_t xcb_drawable);
 
 /* Set the color of a pen. */
 void set_pen_color(xcb_render_picture_t pen, xcb_render_color_t color);
 
-/* Creates a picture with width and height set to 1. */
+/* Create a picture with width and height set to 1. */
 xcb_render_picture_t create_pen(xcb_render_color_t color);
 
 /* Helper function to convert an RRGGBB color into an xcb color. */
@@ -61,13 +61,13 @@ static inline void convert_color_to_xcb_color(xcb_render_color_t *xcb_color,
     xcb_color->blue = (color & 0xff) << 8;
 }
 
-/* This sets the globally used font for rendering.
+/* Set the globally used font for rendering.
  *
  * @return OK on success or ERROR when the font was not found.
  */
 int set_font(const utf8_t *query);
 
-/* This draws text to a given drawable using the current font. */
+/* Draw text to a given drawable using the current font. */
 int draw_text(xcb_drawable_t xcb_drawable, const utf8_t *utf8, uint32_t length,
         xcb_render_color_t background_color, const xcb_rectangle_t *rectangle,
         xcb_render_picture_t foreground, int32_t x, int32_t y);

--- a/include/window.h
+++ b/include/window.h
@@ -124,7 +124,7 @@ Window *create_window(xcb_window_t xcb);
 void close_window(Window *window);
 
 /* Destroy given window and removes it from the window linked list.
- * This does NOT destroy the underlying xcb window.
+ * This does NOT destroy the underlying X window.
  */
 void destroy_window(Window *window);
 
@@ -152,9 +152,9 @@ void set_window_size(Window *window, int32_t x, int32_t y, uint32_t width,
 /* Put the window on the best suited Z stack position. */
 void update_window_layer(Window *window);
 
-/* Get the internal window that has the associated xcb window.
+/* Get the internal window that has the associated X window.
  *
- * @return NULL when none has this xcb window.
+ * @return NULL when none has this X window.
  */
 Window *get_window_of_xcb_window(xcb_window_t xcb_window);
 

--- a/include/window.h
+++ b/include/window.h
@@ -71,7 +71,7 @@ struct window {
     uint32_t border_size;
     uint32_t border_color;
 
-    /* position and size when the window was in floating mode */
+    /* position/size when the window was in floating mode */
     Rectangle floating;
 
     /* the id of this window */

--- a/include/window_state.h
+++ b/include/window_state.h
@@ -44,6 +44,14 @@ window_mode_t predict_window_mode(Window *window);
 /* Check if @window has a visible border currently. */
 bool has_window_border(Window *window);
 
+/* Add window states to the window's properties. */
+void add_window_states(Window *window, xcb_atom_t *states,
+        uint32_t number_of_states);
+
+/* Remove window states from the window's properties. */
+void remove_window_states(Window *window, xcb_atom_t *states,
+        uint32_t number_of_states);
+
 /* Change the mode to given value and reconfigures the window if it is visible.
  *
  * @force_mode is used to force the change of the window mode.

--- a/include/x11_management.h
+++ b/include/x11_management.h
@@ -97,6 +97,8 @@
     /* CARDINAL */ X(_NET_WM_USER_TIME) \
     /* the name of the locale of the window, fox example: "en_US.UTF-8" */ \
     X(WM_LOCALE_NAME) \
+    /* take focus window message atom */ \
+    X(WM_TAKE_FOCUS) \
     /* delete window message atom */ \
     X(WM_DELETE_WINDOW) \
     /* change state message atom */ \
@@ -345,6 +347,9 @@ void query_existing_windows(void);
 
 /* Set the initial root window properties. */
 void initialize_root_properties(void);
+
+/* Set the input focus to @window. This window may be `NULL`. */
+void set_input_focus(Window *window);
 
 /* Show the client on the X server. */
 void map_client(XClient *client);

--- a/man/fensterchef.1
+++ b/man/fensterchef.1
@@ -71,15 +71,15 @@ before any binding.
     Reload the configuration file
 .PP
 .B A
-    Move to the parent frame
+    Focus the parent frame
 .PP
 .B B
-    Move to the child frame
+    Focus the child frame
 .PP
 .B Shift
 +
 .B A
-    Move to the root frame
+    Focus the root frame
 .PP
 .B Q
     Close the active window

--- a/man/fensterchef.1
+++ b/man/fensterchef.1
@@ -18,9 +18,9 @@ fensterchef - tiling done the right way
     Print the version
 .PP
 .B -d
-.I VERBOSITY
-    Set the output logging verbosity to one of:
-.B all info error nothing
+.IR all | info | error | nothing
+.B (default: info)
+    Set the output logging verbosity
 .PP
 .B --verbose
     Log everything
@@ -28,6 +28,7 @@ fensterchef - tiling done the right way
 .BR -c ,
 .B --config
 .I FILE
+.B (default: ~/.config/fensterchef/fensterchef.config)
     Load
 .I FILE
 as configuration file
@@ -37,6 +38,11 @@ The
 .B fensterchef
 developers thank you for choosing
 .BR fensterchef .
+.B fensterchef
+is an X11 tiling window manager with floating window support and
+a keyboard-centric philosophy although there are also a lot of options for the
+mouse.
+
 If you have used
 .BR ratpoison (1)
 before, than this is a perfect replacement for you as
@@ -84,7 +90,7 @@ before any binding.
 .B Q
     Close the active window
 .PP
-.B \-
+.B -
     Minimize the active window
 .PP
 .B N

--- a/man/fensterchef.1
+++ b/man/fensterchef.1
@@ -8,21 +8,25 @@ fensterchef - tiling done the right way
 .
 .SH OPTIONS
 .PP
--h, --help, --usage
+.BR -h ,
+.BR --help ,
+.B --usage
     Show help
 .PP
--v, --version
+.BR -v ,
+.B --version
     Print the version
 .PP
--d
+.B -d
 .I VERBOSITY
     Set the output logging verbosity to one of:
 .B all info error nothing
 .PP
---verbose
+.B --verbose
     Log everything
 .PP
--c, --config
+.BR -c ,
+.B --config
 .I FILE
     Load
 .I FILE

--- a/src/action.c
+++ b/src/action.c
@@ -245,7 +245,11 @@ void set_showable_tiling_window(bool previous)
         }
     }
 
-    if (valid_window != NULL) {
+    if (valid_window == NULL) {
+        set_notification((utf8_t*) "No other window",
+                focus_frame->x + focus_frame->width / 2,
+                focus_frame->y + focus_frame->height / 2);
+    } else {
         show_window(valid_window);
         set_focus_window(valid_window);
     }

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -77,10 +77,10 @@ void reload_user_configuration(void)
             fensterchef_configuration[1] == '/') {
         const char *const home = getenv("HOME");
         if (home == NULL) {
-            LOG("could not get home directory ($HOME is unset)\n");
-        } else {
-            path = xasprintf("%s/%s", home, &fensterchef_configuration[2]);
+            LOG_ERROR("could not get home directory ($HOME is unset)\n");
+            return;
         }
+        path = xasprintf("%s/%s", home, &fensterchef_configuration[2]);
     } else {
         path = xstrdup(fensterchef_configuration);
     }

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -52,6 +52,8 @@ void duplicate_configuration(struct configuration *duplicate)
     if (duplicate->font.name != NULL) {
         duplicate->font.name = (uint8_t*) xstrdup((char*) duplicate->font.name);
     }
+    duplicate->startup.actions = duplicate_actions(duplicate->startup.actions,
+            duplicate->startup.number_of_actions);
     duplicate_configuration_button_bindings(duplicate);
     duplicate_configuration_key_bindings(duplicate);
 }
@@ -59,6 +61,8 @@ void duplicate_configuration(struct configuration *duplicate)
 /* Clear the resources given configuration occupies. */
 void clear_configuration(struct configuration *configuration)
 {
+    free_actions(configuration->startup.actions,
+            configuration->startup.number_of_actions);
     free(configuration->font.name);
     for (uint32_t i = 0; i < configuration->keyboard.number_of_keys; i++) {
         free_actions(configuration->keyboard.keys[i].actions,

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -61,9 +61,19 @@ void duplicate_configuration(struct configuration *duplicate)
 /* Clear the resources given configuration occupies. */
 void clear_configuration(struct configuration *configuration)
 {
+    free(configuration->font.name);
+
     free_actions(configuration->startup.actions,
             configuration->startup.number_of_actions);
-    free(configuration->font.name);
+
+    /* free button bindings */
+    for (uint32_t i = 0; i < configuration->mouse.number_of_buttons; i++) {
+        free_actions(configuration->mouse.buttons[i].actions,
+                configuration->mouse.buttons[i].number_of_actions);
+    }
+    free(configuration->mouse.buttons);
+
+    /* free key bindings */
     for (uint32_t i = 0; i < configuration->keyboard.number_of_keys; i++) {
         free_actions(configuration->keyboard.keys[i].actions,
                 configuration->keyboard.keys[i].number_of_actions);
@@ -237,17 +247,6 @@ void grab_configured_keys(void)
     }
 }
 
-/* Reload the given frame or all sub frames. */
-static void reload_frame_recursively(Frame *frame)
-{
-    if (frame->left != NULL) {
-        reload_frame_recursively(frame->left);
-        reload_frame_recursively(frame->right);
-    } else {
-        reload_frame(frame);
-    }
-}
-
 /* Compare the current configuration with the new configuration and set it. */
 void set_configuration(struct configuration *new_configuration)
 {
@@ -257,22 +256,9 @@ void set_configuration(struct configuration *new_configuration)
     old_configuration = configuration;
     configuration = *new_configuration;
 
-    /* check if font changed */
-    if (configuration.font.name != NULL &&
-            (old_configuration.font.name == NULL ||
-                strcmp((char*) old_configuration.font.name,
-                    (char*) configuration.font.name) != 0)) {
+    /* reload the font */
+    if (configuration.font.name != NULL) {
         set_font(configuration.font.name);
-    }
-
-    /* check if border size or gaps change and reload all frames */
-    if (old_configuration.border.size != configuration.border.size ||
-            old_configuration.gaps.inner != configuration.gaps.inner ||
-            old_configuration.gaps.outer != configuration.gaps.outer) {
-        for (Monitor *monitor = first_monitor; monitor != NULL;
-                monitor = monitor->next) {
-            reload_frame_recursively(monitor->frame);
-        }
     }
 
     /* refresh the border size and color of all windows */
@@ -283,6 +269,13 @@ void set_configuration(struct configuration *new_configuration)
             window->border_color = configuration.border.color;
         }
         window->border_size = configuration.border.size;
+    }
+
+    /* reload all frames */
+    for (Monitor *monitor = first_monitor; monitor != NULL;
+            monitor = monitor->next) {
+        resize_frame(monitor->frame, monitor->frame->x, monitor->frame->y,
+                monitor->frame->width, monitor->frame->height);
     }
 
     /* change border color and size of the notification window */
@@ -358,6 +351,9 @@ int load_configuration_file(const char *file_name,
 
     parser.configuration = destination_configuration;
     *parser.configuration = configuration;
+    /* disregard all previous startup actions */
+    parser.configuration->startup.actions = NULL;
+    parser.configuration->startup.number_of_actions = 0;
     /* disregard all previous bindings */
     parser.configuration->mouse.buttons = NULL;
     parser.configuration->mouse.number_of_buttons = 0;
@@ -418,10 +414,18 @@ int load_configuration_file(const char *file_name,
         return ERROR;
     }
 
+    /* set the existing startup actions if no startup section is specified */
+    if (!parser.has_label[PARSER_LABEL_STARTUP]) {
+        parser.configuration->startup.actions =
+            duplicate_actions(configuration.startup.actions,
+                configuration.startup.number_of_actions);
+        parser.configuration->startup.number_of_actions =
+            configuration.startup.number_of_actions;
+    }
+
     /* set the existing button bindings if no mouse section is specified */
     if (!parser.has_label[PARSER_LABEL_MOUSE]) {
-        parser.configuration->mouse.buttons =
-            configuration.mouse.buttons;
+        parser.configuration->mouse.buttons = configuration.mouse.buttons;
         parser.configuration->mouse.number_of_buttons =
             configuration.mouse.number_of_buttons;
         duplicate_configuration_button_bindings(parser.configuration);
@@ -429,8 +433,7 @@ int load_configuration_file(const char *file_name,
 
     /* set the existing key bindings if no keyboard section is specified */
     if (!parser.has_label[PARSER_LABEL_KEYBOARD]) {
-        parser.configuration->keyboard.keys =
-            configuration.keyboard.keys;
+        parser.configuration->keyboard.keys = configuration.keyboard.keys;
         parser.configuration->keyboard.number_of_keys =
             configuration.keyboard.number_of_keys;
         duplicate_configuration_key_bindings(parser.configuration);

--- a/src/configuration_parser.c
+++ b/src/configuration_parser.c
@@ -185,8 +185,8 @@ static const struct parser_label_name {
 } labels[PARSER_LABEL_MAX] = {
     [PARSER_LABEL_GENERAL] = {
         "general", NULL, {
-        { "move-overlap", PARSER_DATA_TYPE_INTEGER,
-            offsetof(struct configuration, general.move_overlap) },
+        { "overlap-percentage", PARSER_DATA_TYPE_INTEGER,
+            offsetof(struct configuration, general.overlap_percentage) },
         /* null terminate the end */
         { NULL, 0, 0 } }
     },

--- a/src/configuration_parser.c
+++ b/src/configuration_parser.c
@@ -157,9 +157,22 @@ static struct parser_data_type_information {
     }
 };
 
+/* Parse a list of start up actions. */
+static parser_error_t parse_startup_actions(Parser *parser);
+
+/* Parse a binding for the mouse. */
+static parser_error_t parse_mouse_binding(Parser *parser);
+
+/* Parse a binding for the keyboard. */
+static parser_error_t parse_keyboard_binding(Parser *parser);
+
 /* variables in the form <name> <value> */
 static const struct parser_label_name {
+    /* the string representation of the label */
     const char *name;
+    /* special handling for a label */
+    parser_error_t (*special_parser)(Parser *parser);
+    /* the variables that can be defined in the label */
     struct parser_label_variable {
         /* name of the variable */
         const char *name;
@@ -170,15 +183,21 @@ static const struct parser_label_name {
     } variables[8];
 } labels[PARSER_LABEL_MAX] = {
     [PARSER_LABEL_GENERAL] = {
-        "general", {
-        { "unused", PARSER_DATA_TYPE_INTEGER,
-            offsetof(struct configuration, general.unused) },
+        "general", NULL, {
+        { "move-overlap", PARSER_DATA_TYPE_INTEGER,
+            offsetof(struct configuration, general.move_overlap) },
+        /* null terminate the end */
+        { NULL, 0, 0 } }
+    },
+
+    [PARSER_LABEL_STARTUP] = {
+        "startup", parse_startup_actions, {
         /* null terminate the end */
         { NULL, 0, 0 } }
     },
 
     [PARSER_LABEL_TILING] = {
-        "tiling", {
+        "tiling", NULL, {
         { "auto-fill-void", PARSER_DATA_TYPE_BOOLEAN,
             offsetof(struct configuration, tiling.auto_fill_void) },
         { "auto-remove-void", PARSER_DATA_TYPE_BOOLEAN,
@@ -188,7 +207,7 @@ static const struct parser_label_name {
     },
 
     [PARSER_LABEL_FONT] = {
-        "font", {
+        "font", NULL, {
         { "name", PARSER_DATA_TYPE_STRING,
             offsetof(struct configuration, font.name) },
         /* null terminate the end */
@@ -196,7 +215,7 @@ static const struct parser_label_name {
     },
 
     [PARSER_LABEL_BORDER] = {
-        "border", {
+        "border", NULL, {
         { "size", PARSER_DATA_TYPE_INTEGER,
             offsetof(struct configuration, border.size) },
         { "color", PARSER_DATA_TYPE_COLOR,
@@ -208,7 +227,7 @@ static const struct parser_label_name {
     },
 
     [PARSER_LABEL_GAPS] = {
-        "gaps", {
+        "gaps", NULL, {
         { "inner", PARSER_DATA_TYPE_INTEGER,
             offsetof(struct configuration, gaps.inner) },
         { "outer", PARSER_DATA_TYPE_INTEGER,
@@ -218,7 +237,7 @@ static const struct parser_label_name {
     },
 
     [PARSER_LABEL_NOTIFICATION] = {
-        "notification", {
+        "notification", NULL, {
         { "duration", PARSER_DATA_TYPE_INTEGER,
             offsetof(struct configuration, notification.duration) },
         { "padding", PARSER_DATA_TYPE_INTEGER,
@@ -236,7 +255,7 @@ static const struct parser_label_name {
     },
 
     [PARSER_LABEL_MOUSE] = {
-        "mouse", {
+        "mouse", parse_mouse_binding, {
         { "resize-tolerance", PARSER_DATA_TYPE_INTEGER,
             offsetof(struct configuration, mouse.resize_tolerance) },
         { "modifiers", PARSER_DATA_TYPE_MODIFIERS,
@@ -248,7 +267,7 @@ static const struct parser_label_name {
     },
 
     [PARSER_LABEL_KEYBOARD] = {
-        "keyboard", {
+        "keyboard", parse_keyboard_binding, {
         { "modifiers", PARSER_DATA_TYPE_MODIFIERS,
             offsetof(struct configuration, keyboard.modifiers) },
         { "ignore-modifiers", PARSER_DATA_TYPE_MODIFIERS,
@@ -541,6 +560,7 @@ static parser_error_t parse_quad(Parser *parser)
     memset(quad, 0, sizeof(quad));
     for (uint32_t i = 0; i < SIZE(parser->data.quad); i++) {
         skip_space(parser);
+        /* allow a premature end: not enough integers */
         if (parser->line[parser->column] == '\0') {
             break;
         }
@@ -592,24 +612,23 @@ static parser_error_t parse_modifiers(Parser *parser)
     uint16_t modifier;
 
     parser->data.modifiers = 0;
-    error = parse_identifier(parser);
-    while (error == PARSER_SUCCESS) {
+    while (error = parse_identifier(parser), error == PARSER_SUCCESS) {
         modifier = translate_string_to_modifier(parser->identifier);
         if (modifier == INVALID_MODIFIER) {
-            return PARSER_ERROR_INVALID_MODIFIERS;
+            error = PARSER_ERROR_INVALID_MODIFIERS;
+            break;
         }
 
         parser->data.modifiers |= modifier;
 
         /* go to the next '+' */
         if (parse_character(parser) != PARSER_SUCCESS) {
-            return PARSER_SUCCESS;
+            break;
         }
         if (parser->character != '+') {
-            return PARSER_ERROR_UNEXPECTED;
+            error = PARSER_ERROR_UNEXPECTED;
+            break;
         }
-
-        error = parse_identifier(parser);
     }
     return error;
 }
@@ -657,9 +676,6 @@ void clear_data_value(parser_data_type_t type, union parser_data_value *value)
 
 /* Reads modifiers in the from modifier1+modifier2+... but stops at the last
  * identifier in the list, this be accessible in `parser->identifier`.
- *
- * This function assumes that an identifier was loaded into
- * `parser->identifier`.
  */
 static parser_error_t parse_button_or_key_modifiers(Parser *parser,
         uint16_t *modifiers)
@@ -670,27 +686,25 @@ static parser_error_t parse_button_or_key_modifiers(Parser *parser,
     *modifiers = 0;
 
     /* first, read the modifiers and key symbol */
-    error = PARSER_SUCCESS;
-    while (error == PARSER_SUCCESS) {
+    while (error = parse_identifier(parser), error == PARSER_SUCCESS) {
         /* try to find a next '+', if not found, then that must be a none
          * modifier
          */
         skip_space(parser);
         if (parser->line[parser->column] != '+') {
-            return PARSER_SUCCESS;
+            break;
         }
 
         modifier = translate_string_to_modifier(parser->identifier);
         if (modifier == INVALID_MODIFIER) {
-            return PARSER_ERROR_INVALID_MODIFIERS;
+            error = PARSER_ERROR_INVALID_MODIFIERS;
+            break;
         }
 
         *modifiers |= modifier;
 
         /* skip over '+' */
         parser->column++;
-
-        error = parse_identifier(parser);
     }
     return error;
 }
@@ -698,23 +712,24 @@ static parser_error_t parse_button_or_key_modifiers(Parser *parser,
 /* Parse binding flags, e.g.: `--release --transparent` */
 static parser_error_t parse_binding_flags(Parser *parser, uint16_t *flags)
 {
-    parser_error_t error;
+    parser_error_t error = PARSER_SUCCESS;
 
     *flags = 0;
     while (skip_space(parser), parser->line[parser->column] == '-') {
         error = parse_identifier(parser);
         if (error != PARSER_SUCCESS) {
-            return error;
+            break;
         }
         if (strcasecmp(parser->identifier, "--release") == 0) {
             *flags |= BINDING_FLAG_RELEASE;
         } else if (strcasecmp(parser->identifier, "--transparent") == 0) {
             *flags |= BINDING_FLAG_TRANSPARENT;
         } else {
-            return PARSER_ERROR_INVALID_BUTTON_FLAG;
+            error = PARSER_ERROR_INVALID_BUTTON_FLAG;
+            break;
         }
     }
-    return PARSER_SUCCESS;
+    return error;
 }
 
 /* Parse a semicolon separated list of actions. */
@@ -727,33 +742,29 @@ static parser_error_t parse_actions(Parser *parser,
     Action *actions = NULL, *action;
     uint32_t number_of_actions = 0;
 
-    while (true) {
-        error = parse_identifier(parser);
-        if (error == PARSER_ERROR_TOO_LONG) {
-            free_actions(actions, number_of_actions);
-            return error;
-        }
+    while (error = parse_identifier(parser), error != PARSER_ERROR_TOO_LONG) {
         if (error != PARSER_SUCCESS) {
-            free_actions(actions, number_of_actions);
-            return PARSER_ERROR_MISSING_ACTION;
+            error = PARSER_ERROR_MISSING_ACTION;
+            break;
         }
 
         RESIZE(actions, number_of_actions + 1);
         action = &actions[number_of_actions];
 
+        /* get the action name */
         action->code = string_to_action(parser->identifier);
         if (action->code == ACTION_NULL) {
-            free_actions(actions, number_of_actions);
-            return PARSER_ERROR_INVALID_ACTION;
+            error = PARSER_ERROR_INVALID_ACTION;
+            break;
         }
         memset(&action->parameter, 0, sizeof(action->parameter));
 
+        /* get the action value */
         const parser_data_type_t data_type = get_action_data_type(action->code);
         if (data_type != PARSER_DATA_TYPE_VOID) {
             error = data_types[data_type].parse(parser);
             if (error != PARSER_SUCCESS) {
-                free_actions(actions, number_of_actions);
-                return error;
+                break;
             }
             action->parameter = parser->data;
         }
@@ -768,15 +779,17 @@ static parser_error_t parse_actions(Parser *parser,
         parser->column++;
     }
 
+    if (error != PARSER_SUCCESS) {
+        free_actions(actions, number_of_actions);
+        return error;
+    }
+
     *destination_actions = actions;
     *destination_number_of_actions = number_of_actions;
     return PARSER_SUCCESS;
 }
 
-/* Parse a mousebinding, e.g.: `Button2 close-window`.
- *
- * This function assumes that an identifier was loaded into @parser.
- */
+/* Parse a mousebinding, e.g.: `Button2 close-window`. */
 static parser_error_t parse_button(Parser *parser)
 {
     parser_error_t error;
@@ -806,10 +819,7 @@ static parser_error_t parse_button(Parser *parser)
     return PARSER_SUCCESS;
 }
 
-/* Parse a keybinding, e.g.: `Shift+v split-horizontally ; move-right`.
- *
- * This function assumes that an identifier was loaded into @parser.
- */
+/* Parse a keybinding, e.g.: `Shift+v split-horizontally ; move-right`. */
 static parser_error_t parse_key(Parser *parser)
 {
     parser_error_t error;
@@ -852,13 +862,90 @@ static parser_error_t merge_default_keyboard(Parser *parser)
     return PARSER_SUCCESS;
 }
 
+/* Parse a list of start up actions. */
+static parser_error_t parse_startup_actions(Parser *parser)
+{
+    parser_error_t error;
+    Action *actions;
+    uint32_t number_of_actions;
+
+    error = parse_actions(parser, &actions, &number_of_actions);
+    if (error != PARSER_SUCCESS) {
+        return error;
+    }
+
+    /* append the parsed actions to the startup actions */
+    RESIZE(parser->configuration->startup.actions,
+            parser->configuration->startup.number_of_actions +
+                number_of_actions);
+    memcpy(&parser->configuration->startup.actions[
+                parser->configuration->startup.number_of_actions],
+            actions,
+            sizeof(*actions) * number_of_actions);
+    parser->configuration->startup.number_of_actions += number_of_actions;
+    free(actions);
+    return PARSER_SUCCESS;
+}
+
+/* Parse a binding for the mouse. */
+static parser_error_t parse_mouse_binding(Parser *parser)
+{
+    parser_error_t error;
+    struct configuration_button *button;
+
+    error = parse_button(parser);
+    if (error != PARSER_SUCCESS) {
+        return error;
+    }
+
+    button = find_configured_button(parser->configuration,
+            parser->button.modifiers, parser->button.index,
+            parser->button.flags);
+
+    if (button != NULL) {
+        free_actions(button->actions, button->number_of_actions);
+    } else {
+        RESIZE(parser->configuration->mouse.buttons,
+                parser->configuration->mouse.number_of_buttons + 1);
+        button = &parser->configuration->mouse.buttons[
+            parser->configuration->mouse.number_of_buttons];
+        parser->configuration->mouse.number_of_buttons++;
+    }
+    *button = parser->button;
+    return PARSER_SUCCESS;
+}
+
+/* Parse a binding for the keyboard. */
+static parser_error_t parse_keyboard_binding(Parser *parser)
+{
+    parser_error_t error;
+    struct configuration_key *key;
+
+    error = parse_key(parser);
+    if (error != PARSER_SUCCESS) {
+        return error;
+    }
+
+    key = find_configured_key(parser->configuration, parser->key.modifiers,
+            parser->key.key_symbol, parser->key.flags);
+
+    if (key != NULL) {
+        free_actions(key->actions, key->number_of_actions);
+    } else {
+        RESIZE(parser->configuration->keyboard.keys,
+                parser->configuration->keyboard.number_of_keys + 1);
+        key = &parser->configuration->keyboard.keys[
+            parser->configuration->keyboard.number_of_keys];
+        parser->configuration->keyboard.number_of_keys++;
+    }
+    *key = parser->key;
+    return PARSER_SUCCESS;
+}
+
 /* Parses and handles given textual line. */
 parser_error_t parse_line(Parser *parser)
 {
     parser_error_t error;
-
-    struct configuration_button *button;
-    struct configuration_key *key;
 
     /* remove leading whitespace */
     skip_space(parser);
@@ -944,52 +1031,13 @@ parser_error_t parse_line(Parser *parser)
         }
     }
 
-    /* special handling for defining mousebindings */
-    if (parser->label == PARSER_LABEL_MOUSE) {
-        error = parse_button(parser);
-        if (error != PARSER_SUCCESS) {
-            return error;
-        }
+    /* rewind before the identifier */
+    parser->column = parser->item_start_column;
 
-        button = find_configured_button(parser->configuration,
-                parser->button.modifiers, parser->button.index,
-                parser->button.flags);
-
-        if (button != NULL) {
-            free_actions(button->actions, button->number_of_actions);
-        } else {
-            RESIZE(parser->configuration->mouse.buttons,
-                    parser->configuration->mouse.number_of_buttons + 1);
-            button = &parser->configuration->mouse.buttons[
-                parser->configuration->mouse.number_of_buttons];
-            parser->configuration->mouse.number_of_buttons++;
-        }
-        *button = parser->button;
-        return PARSER_SUCCESS;
+    /* check if the label has a special parser */
+    if (labels[parser->label].special_parser == NULL) {
+        return PARSER_ERROR_INVALID_VARIABLE_NAME;
     }
 
-    /* special handling for defining keybindings */
-    if (parser->label == PARSER_LABEL_KEYBOARD) {
-        error = parse_key(parser);
-        if (error != PARSER_SUCCESS) {
-            return error;
-        }
-
-        key = find_configured_key(parser->configuration, parser->key.modifiers,
-                parser->key.key_symbol, parser->key.flags);
-
-        if (key != NULL) {
-            free_actions(key->actions, key->number_of_actions);
-        } else {
-            RESIZE(parser->configuration->keyboard.keys,
-                    parser->configuration->keyboard.number_of_keys + 1);
-            key = &parser->configuration->keyboard.keys[
-                parser->configuration->keyboard.number_of_keys];
-            parser->configuration->keyboard.number_of_keys++;
-        }
-        *key = parser->key;
-        return PARSER_SUCCESS;
-    }
-
-    return PARSER_ERROR_INVALID_VARIABLE_NAME;
+    return labels[parser->label].special_parser(parser);
 }

--- a/src/default_configuration.c
+++ b/src/default_configuration.c
@@ -31,8 +31,8 @@ static const struct configuration default_configuration = {
 
     /* default gap settings: no gaps */
     .gaps = {
-        .inner = 0,
-        .outer = 0
+        .inner = { 0, 0, 0, 0 },
+        .outer = { 0, 0, 0, 0 }
     },
 
     /* default notification settings */

--- a/src/default_configuration.c
+++ b/src/default_configuration.c
@@ -6,9 +6,9 @@
 
 /* the default configuration */
 static const struct configuration default_configuration = {
-    /* default general settings, currently not used for anything */
+    /* default general settings */
     .general = {
-        .unused = 0
+        .move_overlap = 80
     },
 
     /* default tiling settings: fill empty frames but never automatically remove
@@ -37,7 +37,7 @@ static const struct configuration default_configuration = {
 
     /* default notification settings */
     .notification = {
-        .duration = 3,
+        .duration = 2,
         .padding = 6,
         .border_color = 0x000000,
         .border_size = 1,
@@ -191,10 +191,10 @@ void merge_with_default_key_bindings(struct configuration *configuration)
         { 0, 0, XK_s, { .code = ACTION_SPLIT_VERTICALLY } },
 
         /* move between frames */
-        { 0, 0, XK_k, { .code = ACTION_MOVE_UP } },
-        { 0, 0, XK_h, { .code = ACTION_MOVE_LEFT } },
-        { 0, 0, XK_l, { .code = ACTION_MOVE_RIGHT } },
-        { 0, 0, XK_j, { .code = ACTION_MOVE_DOWN } },
+        { 0, 0, XK_k, { .code = ACTION_FOCUS_UP } },
+        { 0, 0, XK_h, { .code = ACTION_FOCUS_LEFT } },
+        { 0, 0, XK_l, { .code = ACTION_FOCUS_RIGHT } },
+        { 0, 0, XK_j, { .code = ACTION_FOCUS_DOWN } },
 
         /* exchange frames */
         { XCB_MOD_MASK_SHIFT, 0, XK_k, { .code = ACTION_EXCHANGE_UP } },
@@ -246,7 +246,8 @@ void merge_with_default_key_bindings(struct configuration *configuration)
         /* run the terminal or xterm as fall back */
         { 0, 0, XK_Return, { ACTION_RUN, {
                 .string = (uint8_t*)
-                    "[ -n \"$TERMINAL\" ] && \"$TERMINAL\" || xterm" } } },
+                    "[ -n \"$TERMINAL\" ] && exec \"$TERMINAL\" || exec xterm"
+            } } },
 
         /* quit fensterchef */
         { XCB_MOD_MASK_CONTROL | XCB_MOD_MASK_SHIFT, 0, XK_e,

--- a/src/default_configuration.c
+++ b/src/default_configuration.c
@@ -243,9 +243,10 @@ void merge_with_default_key_bindings(struct configuration *configuration)
         /* show the interactive window list */
         { 0, 0, XK_w, { .code = ACTION_SHOW_WINDOW_LIST } },
 
-        /* run xterm */
+        /* run the terminal or xterm as fall back */
         { 0, 0, XK_Return, { ACTION_RUN, {
-                .string = (uint8_t*) "/usr/bin/xterm" } } },
+                .string = (uint8_t*)
+                    "[ -n \"$TERMINAL\" ] && \"$TERMINAL\" || xterm" } } },
 
         /* quit fensterchef */
         { XCB_MOD_MASK_CONTROL | XCB_MOD_MASK_SHIFT, 0, XK_e,

--- a/src/default_configuration.c
+++ b/src/default_configuration.c
@@ -8,7 +8,7 @@
 static const struct configuration default_configuration = {
     /* default general settings */
     .general = {
-        .move_overlap = 80
+        .overlap_percentage = 80
     },
 
     /* default tiling settings: fill empty frames but never automatically remove

--- a/src/event.c
+++ b/src/event.c
@@ -218,23 +218,27 @@ void synchronize_with_server(void)
 /* Set the input focus on the X server. */
 static void synchronize_focus_with_server(Window *old_focus_window)
 {
-    /* give the new window focus */
-    if (old_focus_window != focus_window) {
-        xcb_window_t focus_id;
+    xcb_window_t focus_id;
+    xcb_window_t active_id;
 
-        if (focus_window == NULL) {
-            LOG("removed focus from all windows\n");
-            focus_id = screen->root;
-        } else {
-            focus_id = focus_window->client.id;
-        }
+    if (old_focus_window == focus_window) {
+        return;
+    };
 
-        xcb_set_input_focus(connection, XCB_INPUT_FOCUS_NONE, focus_id,
-                XCB_CURRENT_TIME);
-
-        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
-                ATOM(_NET_ACTIVE_WINDOW), XCB_ATOM_WINDOW, 32, 1, &focus_id);
+    if (focus_window == NULL) {
+        LOG("removed focus from all windows\n");
+        focus_id = wm_check_window;
+        active_id = screen->root;
+    } else {
+        focus_id = focus_window->client.id;
+        active_id = focus_id;
     }
+
+    xcb_set_input_focus(connection, XCB_INPUT_FOCUS_NONE, focus_id,
+            XCB_CURRENT_TIME);
+
+    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
+            ATOM(_NET_ACTIVE_WINDOW), XCB_ATOM_WINDOW, 32, 1, &active_id);
 }
 
 /* Run the next cycle of the event loop. */

--- a/src/event.c
+++ b/src/event.c
@@ -221,32 +221,6 @@ void synchronize_with_server(void)
     }
 }
 
-/* Set the input focus on the X server. */
-static void synchronize_focus_with_server(Window *old_focus_window)
-{
-    xcb_window_t focus_id;
-    xcb_window_t active_id;
-
-    if (old_focus_window == focus_window) {
-        return;
-    };
-
-    if (focus_window == NULL) {
-        LOG("removed focus from all windows\n");
-        focus_id = wm_check_window;
-        active_id = screen->root;
-    } else {
-        focus_id = focus_window->client.id;
-        active_id = focus_id;
-    }
-
-    xcb_set_input_focus(connection, XCB_INPUT_FOCUS_NONE, focus_id,
-            XCB_CURRENT_TIME);
-
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
-            ATOM(_NET_ACTIVE_WINDOW), XCB_ATOM_WINDOW, 32, 1, &active_id);
-}
-
 /* Run the next cycle of the event loop. */
 int next_cycle(void)
 {
@@ -294,7 +268,10 @@ int next_cycle(void)
             synchronize_client_list();
             has_client_list_changed = false;
         }
-        synchronize_focus_with_server(old_focus_window);
+
+        if (old_focus_window != focus_window) {
+            set_input_focus(focus_window);
+        }
     }
 
     if (has_timer_expired) {

--- a/src/fensterchef.c
+++ b/src/fensterchef.c
@@ -16,7 +16,13 @@ const char *fensterchef_configuration = FENSTERCHEF_CONFIGURATION;
 void quit_fensterchef(int exit_code)
 {
     LOG("quitting fensterchef with exit code: %d\n", exit_code);
-    /* TODO: maybe free all resources to show we care? */
+    /* TODO: maybe free all resources to show we care? that would include:
+     * - frames
+     * - windows
+     * - monitors
+     * - configuration
+     * - render cache
+     */
     deinitialize_renderer();
     xcb_disconnect(connection);
     exit(exit_code);

--- a/src/fensterchef.c
+++ b/src/fensterchef.c
@@ -12,18 +12,12 @@ bool is_fensterchef_running;
 /* the path of the configuration file */
 const char *fensterchef_configuration = FENSTERCHEF_CONFIGURATION;
 
-/* Close the connection to xcb and exit the program with given exit code. */
+/* Close the connection to the X server and exit the program with given exit
+ * code.
+ */
 void quit_fensterchef(int exit_code)
 {
     LOG("quitting fensterchef with exit code: %d\n", exit_code);
-    /* TODO: maybe free all resources to show we care? that would include:
-     * - frames
-     * - windows
-     * - monitors
-     * - configuration
-     * - render cache
-     */
-    deinitialize_renderer();
     xcb_disconnect(connection);
     exit(exit_code);
 }

--- a/src/frame.c
+++ b/src/frame.c
@@ -5,6 +5,7 @@
 #include "frame.h"
 #include "log.h"
 #include "monitor.h"
+#include "stash_frame.h"
 #include "utility.h"
 #include "window.h"
 
@@ -170,20 +171,19 @@ void set_focus_frame(Frame *frame)
     LOG("frame %F was focused\n", frame);
 }
 
-/* Focus @window and the frame it is in. */
+/* Focus @window and the frame it is contained in if any. */
 void set_focus_window_with_frame(Window *window)
 {
     if (window == NULL) {
         set_focus_window(NULL);
-        return;
-    }
-
-    if (focus_frame->window != focus_window) {
-        LOG("frame %F was focused with window %W\n", focus_frame, window);
+    /* if the frame the window is contained in is already focused */
+    } else if (focus_frame->window == window) {
         set_focus_window(window);
     } else {
         Frame *const frame = get_frame_of_window(window);
-        if (frame != NULL) {
+        if (frame == NULL) {
+            set_focus_window(window);
+        } else {
             set_focus_frame(frame);
         }
     }

--- a/src/frame.c
+++ b/src/frame.c
@@ -173,18 +173,19 @@ void set_focus_frame(Frame *frame)
 /* Focus @window and the frame it is in. */
 void set_focus_window_with_frame(Window *window)
 {
-    Frame *frame;
-
     if (window == NULL) {
         set_focus_window(NULL);
         return;
     }
 
-    frame = get_frame_of_window(window);
-    if (frame != NULL) {
-        set_focus_frame(frame);
-    } else {
+    if (focus_frame->window != focus_window) {
+        LOG("frame %F was focused with window %W\n", focus_frame, window);
         set_focus_window(window);
+    } else {
+        Frame *const frame = get_frame_of_window(window);
+        if (frame != NULL) {
+            set_focus_frame(frame);
+        }
     }
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -992,9 +992,11 @@ static void log_event(xcb_generic_event_t *event)
     uint8_t event_type;
 
     event_type = (event->response_type & ~0x80);
-    if (event_type == randr_event_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
+    if (randr_event_base > 0 &&
+            event_type == randr_event_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
         fputs("RandrScreenChangeNotify", stderr);
-    } else if (event_type == randr_event_base + XCB_RANDR_NOTIFY) {
+    } else if (randr_event_base > 0 &&
+            event_type == randr_event_base + XCB_RANDR_NOTIFY) {
         fputs("RandrNotify", stderr);
     } else if (xcb_event_get_label(event_type) != NULL) {
         fputs(xcb_event_get_label(event_type), stderr);
@@ -1016,7 +1018,8 @@ static void log_event(xcb_generic_event_t *event)
     fprintf(stderr, "(sequence=");
     log_unsigned(event->sequence);
 
-    if (event_type == randr_event_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
+    if (randr_event_base > 0 &&
+            event_type == randr_event_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
         log_randr_screen_change_notify_event(
                 (xcb_randr_screen_change_notify_event_t*) event);
         fputs(")", stderr);

--- a/src/log.c
+++ b/src/log.c
@@ -1183,39 +1183,44 @@ static void log_actions(const Action *actions, uint32_t number_of_actions)
         if (i > 0) {
             fputs(" ; ", stderr);
         }
-        fprintf(stderr, COLOR(CYAN) "%s" CLEAR_COLOR " ",
+        fprintf(stderr, COLOR(CYAN) "%s" CLEAR_COLOR,
                 action_to_string(actions[i].code));
         switch (get_action_data_type(actions[i].code)) {
         case PARSER_DATA_TYPE_VOID:
+            /* nothing */
             break;
 
         case PARSER_DATA_TYPE_BOOLEAN:
+            fputc(' ', stderr);
             log_boolean(actions[i].parameter.boolean);
             break;
 
         case PARSER_DATA_TYPE_STRING:
+            fputc(' ', stderr);
             fprintf(stderr, COLOR(GREEN) "%s" CLEAR_COLOR,
                     (char*) actions[i].parameter.string);
             break;
 
         case PARSER_DATA_TYPE_INTEGER:
+            fputc(' ', stderr);
             log_integer(actions[i].parameter.integer);
             break;
 
         case PARSER_DATA_TYPE_QUAD:
             fprintf(stderr, COLOR(GREEN)
-                        "%" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+                        " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
                         CLEAR_COLOR,
                     actions[i].parameter.quad[0], actions[i].parameter.quad[1],
                     actions[i].parameter.quad[2], actions[i].parameter.quad[3]);
             break;
 
         case PARSER_DATA_TYPE_COLOR:
-            fprintf(stderr, COLOR(YELLOW) "#%06x" CLEAR_COLOR,
+            fprintf(stderr, COLOR(YELLOW) " #%06x" CLEAR_COLOR,
                 actions[i].parameter.color);
             break;
 
         case PARSER_DATA_TYPE_MODIFIERS:
+            fputc(' ', stderr);
             log_modifiers(actions[i].parameter.modifiers);
             break;
         }

--- a/src/log.c
+++ b/src/log.c
@@ -1180,8 +1180,8 @@ static void log_frame(const Frame *frame)
 static void log_actions(const Action *actions, uint32_t number_of_actions)
 {
     for (uint32_t i = 0; i < number_of_actions; i++) {
-        if (number_of_actions > 1) {
-            fputs("\n\t", stderr);
+        if (i > 0) {
+            fputs(" ; ", stderr);
         }
         fprintf(stderr, COLOR(CYAN) "%s" CLEAR_COLOR " ",
                 action_to_string(actions[i].code));

--- a/src/log.c
+++ b/src/log.c
@@ -16,7 +16,7 @@
 #include "x11_management.h"
 
 /* the severity of the logging */
-log_severity_t log_severity;
+log_severity_t log_severity = LOG_SEVERITY_INFO;
 
 /***********************/
 /** String conversion **/
@@ -1261,7 +1261,7 @@ void log_formatted(log_severity_t severity, const char *file, int line,
     current_time = time(NULL);
     tm = localtime(&current_time);
     strftime(buffer, sizeof(buffer),
-            severity == SEVERITY_ERROR ? COLOR(RED) "{%F %T}" :
+            severity == LOG_SEVERITY_ERROR ? COLOR(RED) "{%F %T}" :
                 COLOR(GREEN) "[%F %T]", tm);
     fprintf(stderr, "%s" COLOR(YELLOW) "(%s:%d) " CLEAR_COLOR,
             buffer, file, line);

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,8 @@ int main(int argc, char **argv)
 
     /* manage the windows that are already there */
     query_existing_windows();
+    synchronize_with_server();
+    synchronize_client_list();
 
     /* before entering the loop, flush all the initialization calls */
     xcb_flush(connection);

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,8 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    LOG("parsed arguments, starting to log\n");
+
     /* initialize the X connection and X atoms */
     if (initialize_x11() != OK) {
         quit_fensterchef(EXIT_FAILURE);

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,8 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    LOG("welcome to " FENSTERCHEF_NAME " " FENSTERCHEF_VERSION "\n");
+    LOG("the configuration file may reside in %s\n", fensterchef_configuration);
     LOG("parsed arguments, starting to log\n");
 
     /* initialize the X connection and X atoms */

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "monitor.h"
 #include "program_options.h"
 #include "render.h"
+#include "window.h"
 #include "x11_management.h"
 #include "xalloc.h"
 
@@ -58,6 +59,16 @@ int main(int argc, char **argv)
 
     /* manage the windows that are already there */
     query_existing_windows();
+
+    /* run all startup actions */
+    LOG("running startup actions: %A\n",
+            configuration.startup.number_of_actions,
+            configuration.startup.actions);
+    for (uint32_t i = 0; i < configuration.startup.number_of_actions; i++) {
+        do_action(&configuration.startup.actions[i], focus_window);
+    }
+
+    /* do an inital synchronization */
     synchronize_with_server();
     synchronize_client_list();
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -288,7 +288,8 @@ void merge_monitors(Monitor *monitors)
         next_monitor = monitor->next;
         if (monitor->frame != NULL) {
             /* make sure no broken frame focus remains */
-            if (get_root_frame(focus_frame) == monitor->frame) {
+            if (focus_frame != NULL &&
+                    get_root_frame(focus_frame) == monitor->frame) {
                 focus_frame = NULL;
             }
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -254,6 +254,7 @@ Monitor *query_monitors(void)
 
         if (output->crtc == XCB_NONE) {
             LOG("ignored output %.*s: no crtc\n", name_length, name);
+            free(output);
             continue;
         }
 
@@ -268,6 +269,7 @@ Monitor *query_monitors(void)
             LOG_ERROR("output %.*s gave a NULL crtc: %E\n", name_length, name,
                     error);
             free(error);
+            free(output);
             continue;
         }
 
@@ -295,6 +297,7 @@ Monitor *query_monitors(void)
         monitor->height = crtc->height;
 
         free(crtc);
+        free(output);
     }
 
     /* add the primary monitor to the start of the list */
@@ -302,6 +305,8 @@ Monitor *query_monitors(void)
         primary_monitor->next = first_monitor;
         first_monitor = primary_monitor;
     }
+
+    free(resources);
 
     return first_monitor;
 }

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -166,8 +166,8 @@ Window *get_window_covering_monitor(Monitor *monitor)
             continue;
         }
         area = (uint64_t) overlap.width * overlap.height;
-        if (area * 100 / monitor_area >= configuration.general.move_overlap &&
-                area >= best_area) {
+        if (area * 100 / monitor_area >=
+                configuration.general.overlap_percentage && area >= best_area) {
             best_window = window;
             best_area = area;
         }

--- a/src/program_options.c
+++ b/src/program_options.c
@@ -48,7 +48,7 @@ static void print_usage(void)
             error                   only log errors\n\
             nothing                 log nothing\n\
         --verbose                   log everything\n\
-        -c, --config    FILE        set the path of the configuration",
+        -c, --config    FILE        set the path of the configuration\n",
         stderr);
 
 }
@@ -87,7 +87,7 @@ static int handle_option(option_t option, char *value)
     /* change of logging verbosity */
     case OPTION_VERBOSITY:
         for (log_severity_t i = 0; i < SIZE(verbosities); i++) {
-            if (strcmp(verbosities[i], value) == 0) {
+            if (strcasecmp(verbosities[i], value) == 0) {
                 log_severity = i;
                 return OK;
             }

--- a/src/program_options.c
+++ b/src/program_options.c
@@ -66,10 +66,10 @@ static void print_version(void)
 static int handle_option(option_t option, char *value)
 {
     const char *verbosities[] = {
-        [SEVERITY_ALL] = "all",
-        [SEVERITY_INFO] = "info",
-        [SEVERITY_ERROR] = "error",
-        [SEVERITY_NOTHING] = "nothing",
+        [LOG_SEVERITY_ALL] = "all",
+        [LOG_SEVERITY_INFO] = "info",
+        [LOG_SEVERITY_ERROR] = "error",
+        [LOG_SEVERITY_NOTHING] = "nothing",
     };
 
     switch (option) {
@@ -102,7 +102,7 @@ static int handle_option(option_t option, char *value)
 
     /* verbose logging */
     case OPTION_VERBOSE:
-        log_severity = SEVERITY_ALL;
+        log_severity = LOG_SEVERITY_ALL;
         return OK;
 
     /* set the configuration */

--- a/src/render.c
+++ b/src/render.c
@@ -9,13 +9,13 @@
 #include "x11_management.h"
 
 /* TODO: how do we make colored emojis work?
- * I tried to but color formats other than 8 bit colors
+ * I tried to but color formats other than 8 bit colors do not work
  */
 
 /* the render formats for pictures */
 static xcb_render_query_pict_formats_reply_t *formats;
 
-/* graphical objects with the id referring to the xcb id */
+/* graphical objects with the id referring to the X server id */
 uint32_t stock_objects[STOCK_MAX];
 
 /* the font used for rendering */
@@ -36,8 +36,11 @@ static struct font {
 
 /* a mapping from drawable to picture */
 static struct window_picture_cache {
+    /* the id of the drawable */
     xcb_drawable_t xcb_drawable;
+    /* the picture created for the drawable */
     xcb_render_picture_t picture;
+    /* the next cache object in the linked list */
     struct window_picture_cache *next;
 } *window_picture_cache_head;
 
@@ -212,7 +215,7 @@ int initialize_renderer(void)
     return OK;
 }
 
-/* Frees all resources associated to rendering. */
+/* Free all resources associated to rendering. */
 void deinitialize_renderer(void)
 {
     struct window_picture_cache *cache, *next;
@@ -240,11 +243,11 @@ void deinitialize_renderer(void)
     FcFini();
 }
 
-/* Creates a picture for the given window (or retrieves it from the cache).
+/* Create a picture for the given window (or retrieve it from the cache).
  *
  * The cached items do not need to be cleared ever since they are only for the
  * two fensterchef windows (notification and window list) which only get cleared
- * whin fensterchef quits.
+ * when fensterchef quits.
  */
 xcb_render_picture_t cache_window_picture(xcb_drawable_t xcb_drawable)
 {
@@ -310,7 +313,7 @@ void set_pen_color(xcb_render_picture_t pen, xcb_render_color_t color)
         color, 1, &rectangle);
 }
 
-/* Creates a picture with width and height set to 1. */
+/* Create a picture with width and height set to 1. */
 xcb_render_picture_t create_pen(xcb_render_color_t color)
 {
     xcb_pixmap_t pixmap;
@@ -657,7 +660,7 @@ static int cache_glyph(uint32_t glyph, FT_Pos *advance)
     return OK;
 }
 
-/* This draws text to a given picture using the current font. */
+/* Draw text to a given drawable using the current font. */
 int draw_text(xcb_drawable_t xcb_drawable, const utf8_t *utf8, uint32_t length,
         xcb_render_color_t background_color, const xcb_rectangle_t *rectangle,
         xcb_render_picture_t foreground, int32_t x, int32_t y)

--- a/src/tiling.c
+++ b/src/tiling.c
@@ -126,9 +126,6 @@ Frame *get_below_frame(Frame *frame)
 /* Get the minimum size the given frame should have. */
 static void get_minimum_frame_size(Frame *frame, Size *size)
 {
-    Frame *root;
-
-    root = get_root_frame(frame);
     if (frame->left != NULL) {
         Size left_size, right_size;
 
@@ -144,24 +141,6 @@ static void get_minimum_frame_size(Frame *frame, Size *size)
     } else {
         size->width = FRAME_MINIMUM_SIZE;
         size->height = FRAME_MINIMUM_SIZE;
-    }
-
-    if (frame->x == root->x) {
-        size->width += configuration.gaps.outer;
-    } else {
-        size->width += configuration.gaps.inner;
-    }
-    if (frame->x + frame->width == root->x + root->width) {
-        size->width += configuration.gaps.outer;
-    }
-
-    if (frame->y == root->y) {
-        size->height += configuration.gaps.outer;
-    } else {
-        size->height += configuration.gaps.inner;
-    }
-    if (frame->y + frame->height == root->y + root->height) {
-        size->height += configuration.gaps.outer;
     }
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -393,6 +393,13 @@ void set_window_size(Window *window, int32_t x, int32_t y, uint32_t width,
     width = MAX(width, minimum.width);
     height = MAX(height, minimum.height);
 
+    if (window->state.mode == WINDOW_MODE_FLOATING) {
+        window->floating.x = x;
+        window->floating.y = y;
+        window->floating.width = width;
+        window->floating.height = height;
+    }
+
     window->x = x;
     window->y = y;
     window->width = width;

--- a/src/window.c
+++ b/src/window.c
@@ -262,6 +262,9 @@ void destroy_window(Window *window)
 
     has_client_list_changed = true;
 
+    free(window->name);
+    free(window->protocols);
+    free(window->states);
     free(window);
 }
 

--- a/src/window_list.c
+++ b/src/window_list.c
@@ -299,7 +299,7 @@ static void handle_focus_out(xcb_focus_out_event_t *event)
     }
 
     /* refocus the window list */
-    xcb_set_input_focus(connection, XCB_INPUT_FOCUS_NONE,
+    xcb_set_input_focus(connection, XCB_INPUT_FOCUS_POINTER_ROOT,
             window_list.client.id, XCB_CURRENT_TIME);
 }
 
@@ -312,9 +312,7 @@ static void handle_unmap_notify(xcb_unmap_notify_event_t *event)
 
     /* give focus back to the last window */
     if (window_list.should_revert_focus) {
-        xcb_set_input_focus(connection, XCB_INPUT_FOCUS_NONE,
-                focus_window == NULL ? wm_check_window :
-                focus_window->client.id, XCB_CURRENT_TIME);
+        set_input_focus(focus_window);
     }
 }
 
@@ -407,7 +405,7 @@ int show_window_list(void)
             XCB_CONFIG_WINDOW_STACK_MODE, general_values);
 
     /* focus the window list */
-    xcb_set_input_focus(connection, XCB_INPUT_FOCUS_NONE, window_list.client.id,
-            XCB_CURRENT_TIME);
+    xcb_set_input_focus(connection, XCB_INPUT_FOCUS_POINTER_ROOT,
+            window_list.client.id, XCB_CURRENT_TIME);
     return OK;
 }

--- a/src/window_state.c
+++ b/src/window_state.c
@@ -64,23 +64,24 @@ static void configure_floating_size(Window *window)
             height = MIN(height, (uint32_t) window->size_hints.max_height);
         }
 
-        if ((window->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_POSITION)) {
-            x = window->size_hints.x;
-            y = window->size_hints.y;
+        /* center the window */
+        x = monitor->x + (monitor->width - width) / 2;
+        y = monitor->y + (monitor->height - height) / 2;
+    } else {
+        width = window->floating.width;
+        height = window->floating.height;
+        /* if the window would still be in the monitor is was moved to,
+         * restore the position, otherwise center the window
+         */
+        if (get_monitor_from_rectangle(window->floating.x,
+                    window->floating.y, window->floating.width,
+                    window->floating.height) == monitor) {
+            x = window->floating.x;
+            y = window->floating.y;
         } else {
             x = monitor->x + (monitor->width - width) / 2;
             y = monitor->y + (monitor->height - height) / 2;
         }
-
-        window->floating.x = x;
-        window->floating.y = y;
-        window->floating.width = width;
-        window->floating.height = height;
-    } else {
-        x = window->floating.x;
-        y = window->floating.y;
-        width = window->floating.width;
-        height = window->floating.height;
     }
 
     /* consider the window gravity, i.e. where the window wants to be */
@@ -97,8 +98,7 @@ static void configure_fullscreen_size(Window *window)
 {
     Monitor *monitor;
 
-    if (window->fullscreen_monitors.top !=
-            window->fullscreen_monitors.bottom) {
+    if (window->fullscreen_monitors.top != window->fullscreen_monitors.bottom) {
         set_window_size(window, window->fullscreen_monitors.left,
                 window->fullscreen_monitors.top,
                 window->fullscreen_monitors.right -
@@ -116,33 +116,28 @@ static void configure_fullscreen_size(Window *window)
 /* Sets the position and size of the window to a dock window. */
 static void configure_dock_size(Window *window)
 {
+    const uint32_t both_hints = XCB_ICCCM_SIZE_HINT_P_POSITION |
+        XCB_ICCCM_SIZE_HINT_P_SIZE;
     Monitor *monitor;
     int32_t x, y;
     uint32_t width, height;
 
-    if ((window->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_SIZE)) {
-        width = window->size_hints.width;
-        height = window->size_hints.height;
-    } else {
-        width = 0;
-        height = 0;
-    }
-
-    if ((window->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_POSITION)) {
+    /* check if the window has both position and size defined */
+    if ((window->size_hints.flags & both_hints) == both_hints) {
         x = window->size_hints.x;
         y = window->size_hints.y;
+        width = window->size_hints.width;
+        height = window->size_hints.height;
+        monitor = get_monitor_from_rectangle_or_primary(window->x, window->y,
+                window->width, window->height);
     } else {
-        x = window->x;
-        y = window->y;
-    }
+        monitor = get_monitor_from_rectangle_or_primary(window->x, window->y,
+                1, 1);
 
-    monitor = get_monitor_from_rectangle_or_primary(x, y, 1, 1);
-
-    /* if the window does not specify a size itself, then do it based on the
-     * strut the window defines, reasoning is that when the window wants to
-     * occupy screen space, then it should be within that occupied space
-     */
-    if (width == 0 || height == 0) {
+        /* if the window does not specify a size itself, then do it based on the
+         * strut the window defines, reasoning is that when the window wants to
+         * occupy screen space, then it should be within that occupied space
+         */
         if (window->strut.reserved.left != 0) {
             x = monitor->x;
             y = window->strut.left_start_y;
@@ -166,17 +161,13 @@ static void configure_dock_size(Window *window)
                 window->strut.bottom_start_x + 1;
             height = window->strut.reserved.bottom;
         } else {
-            /* TODO: what to do here? what is a dock window without defined size
-             * hints AND without any strut? does it exist?
-             */
-            width = 64;
-            height = 32;
+            width = window->width;
+            height = window->height;
         }
     }
 
     /* consider the window gravity, i.e. where the window wants to be */
-    if ((window->size_hints.flags &
-                XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY)) {
+    if ((window->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY)) {
         adjust_for_window_gravity(monitor, &x, &y, width, height,
             window->size_hints.win_gravity);
     }

--- a/src/window_state.c
+++ b/src/window_state.c
@@ -230,7 +230,7 @@ static void synchronize_allowed_actions(Window *window)
 }
 
 /* Add window states to the window properties. */
-static void add_window_states(Window *window, xcb_atom_t *states,
+void add_window_states(Window *window, xcb_atom_t *states,
         uint32_t number_of_states)
 {
     uint32_t effective_count = 0;
@@ -259,6 +259,11 @@ static void add_window_states(Window *window, xcb_atom_t *states,
         states[effective_count++] = states[i];
     }
 
+    /* check if anything changed */
+    if (effective_count == 0) {
+        return;
+    }
+
     /* append the properties to the list in the X server */
     xcb_change_property(connection, XCB_PROP_MODE_APPEND,
             window->client.id, ATOM(_NET_WM_STATE),
@@ -266,7 +271,7 @@ static void add_window_states(Window *window, xcb_atom_t *states,
 }
 
 /* Remove window states from the window properties. */
-static void remove_window_states(Window *window, xcb_atom_t *states,
+void remove_window_states(Window *window, xcb_atom_t *states,
         uint32_t number_of_states)
 {
     uint32_t i;

--- a/src/x11_management.c
+++ b/src/x11_management.c
@@ -248,21 +248,11 @@ void initialize_root_properties(void)
         ATOM(_NET_CLIENT_LIST),
         ATOM(_NET_CLIENT_LIST_STACKING),
 
-        ATOM(_NET_NUMBER_OF_DESKTOPS),
-
-        ATOM(_NET_DESKTOP_GEOMETRY),
-        ATOM(_NET_DESKTOP_VIEWPORT),
-
-        ATOM(_NET_CURRENT_DESKTOP),
-        ATOM(_NET_DESKTOP_NAMES),
-
         ATOM(_NET_ACTIVE_WINDOW),
 
         ATOM(_NET_WORKAREA),
 
         ATOM(_NET_SUPPORTING_WM_CHECK),
-
-        ATOM(_NET_SHOWING_DESKTOP),
 
         ATOM(_NET_CLOSE_WINDOW),
 
@@ -297,6 +287,7 @@ void initialize_root_properties(void)
         ATOM(_NET_WM_STATE_MAXIMIZED_VERT),
         ATOM(_NET_WM_STATE_MAXIMIZED_HORZ),
         ATOM(_NET_WM_STATE_FULLSCREEN),
+        ATOM(_NET_WM_STATE_HIDDEN),
 
         ATOM(_NET_WM_STRUT),
         ATOM(_NET_WM_STRUT_PARTIAL),
@@ -314,38 +305,6 @@ void initialize_root_properties(void)
             screen->root, ATOM(_NET_SUPPORTING_WM_CHECK), XCB_ATOM_WINDOW,
             32, 1, &wm_check_window);
 
-    /* the current desktop, always 0 */
-    const uint32_t zero = 0;
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
-            ATOM(_NET_CURRENT_DESKTOP), XCB_ATOM_CARDINAL, 32,
-            1, &zero);
-
-    /* origin of the viewport, always (0, 0) */
-    const Point origin = { 0, 0 };
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
-            ATOM(_NET_DESKTOP_VIEWPORT), XCB_ATOM_CARDINAL, 32,
-            2, &origin);
-
-    /* size of the desktop, large desktops are however not supported */
-    const Size geometry = {
-        screen->width_in_pixels,
-        screen->height_in_pixels
-    };
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
-            ATOM(_NET_DESKTOP_GEOMETRY), XCB_ATOM_CARDINAL, 32,
-            2, &geometry);
-
-    /* the number of desktops, always 1 */
-    const uint32_t one = 1;
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
-            ATOM(_NET_NUMBER_OF_DESKTOPS), XCB_ATOM_CARDINAL, 32,
-            1, &one);
-
-    /* set the name of the only desktop */
-    const char *const desktop_name = "0";
-    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
-            ATOM(_NET_DESKTOP_NAMES), ATOM(UTF8_STRING), 8,
-            strlen(desktop_name), desktop_name);
 
     /* set the active window */
     xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,

--- a/src/x11_management.c
+++ b/src/x11_management.c
@@ -182,7 +182,7 @@ int take_control(void)
     xcb_generic_error_t *error;
 
     /* set the mask of the root window so we receive important events like
-     * create notifications
+     * map requests
      */
     general_values[0] = ROOT_EVENT_MASK;
     error = xcb_request_check(connection,
@@ -359,28 +359,31 @@ void initialize_root_properties(void)
     xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root,
             ATOM(_NET_WORKAREA), XCB_ATOM_CARDINAL, 32, 4, &workarea);
 }
-/* Shows the client on the X server. */
+
+/* Show the client on the X server. */
 void map_client(XClient *client)
 {
     if (client->is_mapped) {
         return;
     }
-    client->is_mapped = true;
 
     LOG("showing client %w\n", client->id);
+
+    client->is_mapped = true;
 
     xcb_map_window(connection, client->id);
 }
 
-/* Hides the client on the X server. */
+/* Hide the client on the X server. */
 void unmap_client(XClient *client)
 {
     if (!client->is_mapped) {
         return;
     }
-    client->is_mapped = false;
 
     LOG("hiding client %w\n", client->id);
+
+    client->is_mapped = false;
 
     xcb_unmap_window(connection, client->id);
 }
@@ -567,7 +570,7 @@ static void update_window_transient_for(Window *window)
             window->client.id);
     if (!xcb_icccm_get_wm_transient_for_reply(connection, transient_for_cookie,
                 &window->transient_for, NULL)) {
-        window->transient_for = 0;
+        window->transient_for = XCB_NONE;
     }
 }
 
@@ -658,7 +661,7 @@ bool cache_window_property(Window *window, xcb_atom_t atom)
     return true;
 }
 
-/* Checks if an atom is within the given list of atoms. */
+/* Check if an atom is within the given list of atoms. */
 static bool is_atom_included(const xcb_atom_t *atoms, xcb_atom_t atom)
 {
     if (atoms == NULL) {


### PR DESCRIPTION
Fix up some comments and little issues in `man` and `README.md`.

Also fix two bugs, one involving the double `fork()` not correctly
working. Now child processes are isolated correctly with `setsid()`.
The second bug is a missing NULL check in `monitor.c`.

Moving from one frame to another while crossing a monitor edge now
checks if there is a floating/fullscreen window covering the monitor
with a specific percentage (configurable through `general.move_overlap`)
and then focuses the window (while still focusing the frame it's
supposed to).

Now there is the `[startup]` section which can be filled with actions to
run when the window manager starts. The configuration parser code was
cleaned up a lot as well.

Floating windows are now sized more sensibly as well as dock windows.

Now gaps are a quad so left, top, right bottom gaps are idependently
configurable.

The `_NET_WM_STATE_HIDDEN` state is now being handled.
Now `WM_TAKE_FOCUS` is used to give a window focus.

A few memory leaks were fixed.